### PR TITLE
[DPE-4191] Release pipeline fixed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,7 +67,6 @@ jobs:
       matrix:
         path:
           - .
-          # - tests/integration/app-charm
     name: Build charm
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v11.0.1
     with:
@@ -86,6 +85,3 @@ jobs:
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       cloud: lxd
       juju-agent-version: 3.1.6
-      _beta_allure_report: false
-    permissions:
-      contents: write # Needed for Allure Report beta

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,8 +12,6 @@ jobs:
     name: Tests
     uses: ./.github/workflows/ci.yaml
     secrets: inherit
-    permissions:
-      actions: write  # Needed to manage GitHub Actions cache
 
   build:
     name: Build charm


### PR DESCRIPTION
As @carlcsaposs-canonical [advised](https://chat.canonical.com/canonical/pl/e9dt1wqjdjyxiqfzmyihc3ppgr), the write permssion requests in the Release pipeline were not needed here.