### PR TITLE
[DPE-4419] Moving to Juju 3.1.7 starting from which secret-changed event is also raised for the owner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,4 +84,4 @@ jobs:
       # artifact-prefix: packed-charm-cache-true
       artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
       cloud: lxd
-      juju-agent-version: 3.1.6
+      juju-agent-version: 3.1.7

--- a/lib/charms/operator_libs_linux/v2/snap.py
+++ b/lib/charms/operator_libs_linux/v2/snap.py
@@ -83,7 +83,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 # Regex to locate 7-bit C1 ANSI sequences
@@ -584,13 +584,16 @@ class Snap(object):
                     "Installing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._install(channel, cohort, revision)
-            else:
+                logger.info("The snap installation completed successfully")
+            elif revision is None or revision != self._revision:
                 # The snap is installed, but we are changing it (e.g., switching channels).
                 logger.info(
                     "Refreshing snap %s, revision %s, tracking %s", self._name, revision, channel
                 )
                 self._refresh(channel=channel, cohort=cohort, revision=revision, devmode=devmode)
-            logger.info("The snap installation completed successfully")
+                logger.info("The snap refresh completed successfully")
+            else:
+                logger.info("Refresh of snap %s was unnecessary", self._name)
 
         self._update_snap_apps()
         self._state = state

--- a/src/core/models.py
+++ b/src/core/models.py
@@ -6,7 +6,6 @@
 import logging
 import socket
 import subprocess
-import uuid
 from typing import Literal, MutableMapping
 
 from charms.data_platform_libs.v0.data_interfaces import Data, DataDict
@@ -53,9 +52,6 @@ class StateBase:
 
         if update_fields:
             self._relation_data.update(update_fields)
-            # Hack to ensure a relation-changed event -- no problem if secret-changed is unreliable
-            # see https://bugs.launchpad.net/juju/+bug/2064876
-            self._relation_data.update({"_relation_data_updated": str(uuid.uuid4())})
         for field in delete_fields:
             del self._relation_data[field]
 


### PR DESCRIPTION
Details in the linked Jira ticket (https://warthogs.atlassian.net/browse/DPE-4419): 

Woraround introduced for what was described in: 

[Bug #2064876 “'secret-changed' event not emitted/processed (occu...” : Bugs : Canonical Juju](https://bugs.launchpad.net/juju/+bug/2064876) 

At the end it turns out that there was a mismatch between the local (AWS) and the pipeline execution, where the pipeline was “just” running the Juju version before raising secret-changed for the Secret Owner was introduced.