### PR TITLE
[DPE-4404] Nightly test failures

### DIFF
--- a/lib/charms/data_platform_libs/v0/data_interfaces.py
+++ b/lib/charms/data_platform_libs/v0/data_interfaces.py
@@ -331,7 +331,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 36
+LIBPATCH = 37
 
 PYDEPS = ["ops>=2.0.0"]
 
@@ -656,6 +656,10 @@ class CachedSecret:
     def set_content(self, content: Dict[str, str]) -> None:
         """Setting cached secret content."""
         if not self.meta:
+            return
+
+        # DPE-4182: do not create new revision if the content stay the same
+        if content == self.get_content():
             return
 
         if content:

--- a/src/charm.py
+++ b/src/charm.py
@@ -32,8 +32,8 @@ from literals import (
     MSG_WAITING_FOR_USER_CREDENTIALS,
     PEER,
     RESTART_TIMEOUT,
-    SUBSTRATE,
     SERVER_PORT,
+    SUBSTRATE,
 )
 from managers.config import ConfigManager
 from managers.tls import TLSManager


### PR DESCRIPTION
I've observed a couple of failures of the HA network cut tests ([[1](https://github.com/canonical/opensearch-dashboards-operator/actions/runs/9104949425/job/25063043647)],[[2](https://github.com/canonical/opensearch-dashboards-operator/actions/runs/9072211464/job/24927510116)], [[3](https://github.com/canonical/opensearch-dashboards-operator/actions/runs/9047783022/job/24860254563)], [[4](https://github.com/canonical/opensearch-dashboards-operator/actions/runs/9010854273/job/24757749301)] ). 

Checking a few failures, the primary suspect falls on a specific function fetching the CA certificate file locally (to use it for checking HTTPS access to the Dashboard).

Securizing that call seem to resolve the issue (I've re-run the HA network cut pipeline (1.5h) 4 times, all :green_circle: )

Furthermore related logging is increased as helper functions were too quiet.