### PR TITLE
[DPE-4767] HA network cut tests stabilization

### DIFF
--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -22,7 +22,7 @@ this charm library.
 Using the `COSAgentProvider` object only requires instantiating it,
 typically in the `__init__` method of your charm (the one which sends telemetry).
 
-The constructor of `COSAgentProvider` has only one required and nine optional parameters:
+The constructor of `COSAgentProvider` has only one required and ten optional parameters:
 
 ```python
     def __init__(
@@ -36,6 +36,7 @@ The constructor of `COSAgentProvider` has only one required and nine optional pa
         log_slots: Optional[List[str]] = None,
         dashboard_dirs: Optional[List[str]] = None,
         refresh_events: Optional[List] = None,
+        tracing_protocols: Optional[List[str]] = None,
         scrape_configs: Optional[Union[List[Dict], Callable]] = None,
     ):
 ```
@@ -64,6 +65,8 @@ The constructor of `COSAgentProvider` has only one required and nine optional pa
 - `dashboard_dirs`: List of directories where the dashboards are stored in the Charmed Operator.
 
 - `refresh_events`: List of events on which to refresh relation data.
+
+- `tracing_protocols`: List of requested tracing protocols that the charm requires to send traces.
 
 - `scrape_configs`: List of standard scrape_configs dicts or a callable that returns the list in
     case the configs need to be generated dynamically. The contents of this list will be merged
@@ -108,6 +111,7 @@ class TelemetryProviderCharm(CharmBase):
             log_slots=["my-app:slot"],
             dashboard_dirs=["./src/dashboards_1", "./src/dashboards_2"],
             refresh_events=["update-status", "upgrade-charm"],
+            tracing_protocols=["otlp_http", "otlp_grpc"],
             scrape_configs=[
                 {
                     "job_name": "custom_job",
@@ -249,7 +253,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["cosl", "pydantic"]
 

--- a/lib/charms/grafana_agent/v0/cos_agent.py
+++ b/lib/charms/grafana_agent/v0/cos_agent.py
@@ -206,24 +206,35 @@ class GrafanaAgentMachineCharm(GrafanaAgentCharm)
 ```
 """
 
+import enum
 import json
 import logging
+import socket
 from collections import namedtuple
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, ClassVar, Dict, List, Optional, Set, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    ClassVar,
+    Dict,
+    List,
+    Literal,
+    MutableMapping,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
 
+import pydantic
 from cosl import GrafanaDashboard, JujuTopology
 from cosl.rules import AlertRules
 from ops.charm import RelationChangedEvent
 from ops.framework import EventBase, EventSource, Object, ObjectEvents
-from ops.model import Relation
+from ops.model import ModelError, Relation
 from ops.testing import CharmType
-
-try:
-    import pydantic.v1 as pydantic
-except ImportError:
-    import pydantic
 
 if TYPE_CHECKING:
     try:
@@ -238,7 +249,7 @@ if TYPE_CHECKING:
 
 LIBID = "dc15fa84cef84ce58155fb84f6c6213a"
 LIBAPI = 0
-LIBPATCH = 9
+LIBPATCH = 10
 
 PYDEPS = ["cosl", "pydantic"]
 
@@ -253,7 +264,207 @@ logger = logging.getLogger(__name__)
 SnapEndpoint = namedtuple("SnapEndpoint", "owner, name")
 
 
-class CosAgentProviderUnitData(pydantic.BaseModel):
+# Note: MutableMapping is imported from the typing module and not collections.abc
+# because subscripting collections.abc.MutableMapping was added in python 3.9, but
+# most of our charms are based on 20.04, which has python 3.8.
+
+_RawDatabag = MutableMapping[str, str]
+
+
+class TransportProtocolType(str, enum.Enum):
+    """Receiver Type."""
+
+    http = "http"
+    grpc = "grpc"
+
+
+receiver_protocol_to_transport_protocol = {
+    "zipkin": TransportProtocolType.http,
+    "kafka": TransportProtocolType.http,
+    "tempo_http": TransportProtocolType.http,
+    "tempo_grpc": TransportProtocolType.grpc,
+    "otlp_grpc": TransportProtocolType.grpc,
+    "otlp_http": TransportProtocolType.http,
+    "jaeger_thrift_http": TransportProtocolType.http,
+}
+
+_tracing_receivers_ports = {
+    # OTLP receiver: see
+    #   https://github.com/open-telemetry/opentelemetry-collector/tree/v0.96.0/receiver/otlpreceiver
+    "otlp_http": 4318,
+    "otlp_grpc": 4317,
+    # Jaeger receiver: see
+    #   https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.96.0/receiver/jaegerreceiver
+    "jaeger_grpc": 14250,
+    "jaeger_thrift_http": 14268,
+    # Zipkin receiver: see
+    #   https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.96.0/receiver/zipkinreceiver
+    "zipkin": 9411,
+}
+
+ReceiverProtocol = Literal["otlp_grpc", "otlp_http", "zipkin", "jaeger_thrift_http", "jaeger_grpc"]
+
+
+class TracingError(Exception):
+    """Base class for custom errors raised by tracing."""
+
+
+class NotReadyError(TracingError):
+    """Raised by the provider wrapper if a requirer hasn't published the required data (yet)."""
+
+
+class ProtocolNotRequestedError(TracingError):
+    """Raised if the user attempts to obtain an endpoint for a protocol it did not request."""
+
+
+class DataValidationError(TracingError):
+    """Raised when data validation fails on IPU relation data."""
+
+
+class AmbiguousRelationUsageError(TracingError):
+    """Raised when one wrongly assumes that there can only be one relation on an endpoint."""
+
+
+# TODO we want to eventually use `DatabagModel` from cosl but it likely needs a move to common package first
+if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
+
+    class DatabagModel(pydantic.BaseModel):  # type: ignore
+        """Base databag model."""
+
+        class Config:
+            """Pydantic config."""
+
+            # ignore any extra fields in the databag
+            extra = "ignore"
+            """Ignore any extra fields in the databag."""
+            allow_population_by_field_name = True
+            """Allow instantiating this class by field name (instead of forcing alias)."""
+
+        _NEST_UNDER = None
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            if cls._NEST_UNDER:
+                return cls.parse_obj(json.loads(databag[cls._NEST_UNDER]))
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {f.alias for f in cls.__fields__.values()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.parse_raw(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+
+            if self._NEST_UNDER:
+                databag[self._NEST_UNDER] = self.json(by_alias=True)
+                return databag
+
+            dct = self.dict()
+            for key, field in self.__fields__.items():  # type: ignore
+                value = dct[key]
+                databag[field.alias or key] = json.dumps(value)
+
+            return databag
+
+else:
+    from pydantic import ConfigDict
+
+    class DatabagModel(pydantic.BaseModel):
+        """Base databag model."""
+
+        model_config = ConfigDict(
+            # ignore any extra fields in the databag
+            extra="ignore",
+            # Allow instantiating this class by field name (instead of forcing alias).
+            populate_by_name=True,
+            # Custom config key: whether to nest the whole datastructure (as json)
+            # under a field or spread it out at the toplevel.
+            _NEST_UNDER=None,  # type: ignore
+            arbitrary_types_allowed=True,
+        )
+        """Pydantic config."""
+
+        @classmethod
+        def load(cls, databag: MutableMapping):
+            """Load this model from a Juju databag."""
+            nest_under = cls.model_config.get("_NEST_UNDER")  # type: ignore
+            if nest_under:
+                return cls.model_validate(json.loads(databag[nest_under]))  # type: ignore
+
+            try:
+                data = {
+                    k: json.loads(v)
+                    for k, v in databag.items()
+                    # Don't attempt to parse model-external values
+                    if k in {(f.alias or n) for n, f in cls.__fields__.items()}
+                }
+            except json.JSONDecodeError as e:
+                msg = f"invalid databag contents: expecting json. {databag}"
+                logger.error(msg)
+                raise DataValidationError(msg) from e
+
+            try:
+                return cls.model_validate_json(json.dumps(data))  # type: ignore
+            except pydantic.ValidationError as e:
+                msg = f"failed to validate databag: {databag}"
+                logger.debug(msg, exc_info=True)
+                raise DataValidationError(msg) from e
+
+        def dump(self, databag: Optional[MutableMapping] = None, clear: bool = True):
+            """Write the contents of this model to Juju databag.
+
+            :param databag: the databag to write the data to.
+            :param clear: ensure the databag is cleared before writing it.
+            """
+            if clear and databag:
+                databag.clear()
+
+            if databag is None:
+                databag = {}
+            nest_under = self.model_config.get("_NEST_UNDER")
+            if nest_under:
+                databag[nest_under] = self.model_dump_json(  # type: ignore
+                    by_alias=True,
+                    # skip keys whose values are default
+                    exclude_defaults=True,
+                )
+                return databag
+
+            dct = self.model_dump()  # type: ignore
+            for key, field in self.model_fields.items():  # type: ignore
+                value = dct[key]
+                if value == field.default:
+                    continue
+                databag[field.alias or key] = json.dumps(value)
+
+            return databag
+
+
+class CosAgentProviderUnitData(DatabagModel):
     """Unit databag model for `cos-agent` relation."""
 
     # The following entries are the same for all units of the same principal.
@@ -271,13 +482,16 @@ class CosAgentProviderUnitData(pydantic.BaseModel):
     metrics_scrape_jobs: List[Dict]
     log_slots: List[str]
 
+    # Requested tracing protocols.
+    tracing_protocols: Optional[List[str]] = None
+
     # when this whole datastructure is dumped into a databag, it will be nested under this key.
     # while not strictly necessary (we could have it 'flattened out' into the databag),
     # this simplifies working with the model.
     KEY: ClassVar[str] = "config"
 
 
-class CosAgentPeersUnitData(pydantic.BaseModel):
+class CosAgentPeersUnitData(DatabagModel):
     """Unit databag model for `peers` cos-agent machine charm peer relation."""
 
     # We need the principal unit name and relation metadata to be able to render identifiers
@@ -308,6 +522,83 @@ class CosAgentPeersUnitData(pydantic.BaseModel):
         return self.unit_name.split("/")[0]
 
 
+if int(pydantic.version.VERSION.split(".")[0]) < 2:  # type: ignore
+
+    class ProtocolType(pydantic.BaseModel):  # type: ignore
+        """Protocol Type."""
+
+        class Config:
+            """Pydantic config."""
+
+            use_enum_values = True
+            """Allow serializing enum values."""
+
+        name: str = pydantic.Field(
+            ...,
+            description="Receiver protocol name. What protocols are supported (and what they are called) "
+            "may differ per provider.",
+            examples=["otlp_grpc", "otlp_http", "tempo_http"],
+        )
+
+        type: TransportProtocolType = pydantic.Field(
+            ...,
+            description="The transport protocol used by this receiver.",
+            examples=["http", "grpc"],
+        )
+
+else:
+
+    class ProtocolType(pydantic.BaseModel):
+        """Protocol Type."""
+
+        model_config = pydantic.ConfigDict(
+            # Allow serializing enum values.
+            use_enum_values=True
+        )
+        """Pydantic config."""
+
+        name: str = pydantic.Field(
+            ...,
+            description="Receiver protocol name. What protocols are supported (and what they are called) "
+            "may differ per provider.",
+            examples=["otlp_grpc", "otlp_http", "tempo_http"],
+        )
+
+        type: TransportProtocolType = pydantic.Field(
+            ...,
+            description="The transport protocol used by this receiver.",
+            examples=["http", "grpc"],
+        )
+
+
+class Receiver(pydantic.BaseModel):
+    """Specification of an active receiver."""
+
+    protocol: ProtocolType = pydantic.Field(..., description="Receiver protocol name and type.")
+    url: str = pydantic.Field(
+        ...,
+        description="""URL at which the receiver is reachable. If there's an ingress, it would be the external URL.
+        Otherwise, it would be the service's fqdn or internal IP.
+        If the protocol type is grpc, the url will not contain a scheme.""",
+        examples=[
+            "http://traefik_address:2331",
+            "https://traefik_address:2331",
+            "http://tempo_public_ip:2331",
+            "https://tempo_public_ip:2331",
+            "tempo_public_ip:2331",
+        ],
+    )
+
+
+class CosAgentRequirerUnitData(DatabagModel):  # noqa: D101
+    """Application databag model for the COS-agent requirer."""
+
+    receivers: List[Receiver] = pydantic.Field(
+        ...,
+        description="List of all receivers enabled on the tracing provider.",
+    )
+
+
 class COSAgentProvider(Object):
     """Integration endpoint wrapper for the provider side of the cos_agent interface."""
 
@@ -322,6 +613,7 @@ class COSAgentProvider(Object):
         log_slots: Optional[List[str]] = None,
         dashboard_dirs: Optional[List[str]] = None,
         refresh_events: Optional[List] = None,
+        tracing_protocols: Optional[List[str]] = None,
         *,
         scrape_configs: Optional[Union[List[dict], Callable]] = None,
     ):
@@ -340,6 +632,7 @@ class COSAgentProvider(Object):
                 in the form ["snap-name:slot", ...].
             dashboard_dirs: Directory where the dashboards are stored.
             refresh_events: List of events on which to refresh relation data.
+            tracing_protocols: List of protocols that the charm will be using for sending traces.
             scrape_configs: List of standard scrape_configs dicts or a callable
                 that returns the list in case the configs need to be generated dynamically.
                 The contents of this list will be merged with the contents of `metrics_endpoints`.
@@ -357,6 +650,8 @@ class COSAgentProvider(Object):
         self._log_slots = log_slots or []
         self._dashboard_dirs = dashboard_dirs
         self._refresh_events = refresh_events or [self._charm.on.config_changed]
+        self._tracing_protocols = tracing_protocols
+        self._is_single_endpoint = charm.meta.relations[relation_name].limit == 1
 
         events = self._charm.on[relation_name]
         self.framework.observe(events.relation_joined, self._on_refresh)
@@ -381,6 +676,7 @@ class COSAgentProvider(Object):
                         dashboards=self._dashboards,
                         metrics_scrape_jobs=self._scrape_jobs,
                         log_slots=self._log_slots,
+                        tracing_protocols=self._tracing_protocols,
                     )
                     relation.data[self._charm.unit][data.KEY] = data.json()
                 except (
@@ -444,6 +740,103 @@ class COSAgentProvider(Object):
                 dashboard = GrafanaDashboard._serialize(path.read_bytes())
                 dashboards.append(dashboard)
         return dashboards
+
+    @property
+    def relations(self) -> List[Relation]:
+        """The tracing relations associated with this endpoint."""
+        return self._charm.model.relations[self._relation_name]
+
+    @property
+    def _relation(self) -> Optional[Relation]:
+        """If this wraps a single endpoint, the relation bound to it, if any."""
+        if not self._is_single_endpoint:
+            objname = type(self).__name__
+            raise AmbiguousRelationUsageError(
+                f"This {objname} wraps a {self._relation_name} endpoint that has "
+                "limit != 1. We can't determine what relation, of the possibly many, you are "
+                f"referring to. Please pass a relation instance while calling {objname}, "
+                "or set limit=1 in the charm metadata."
+            )
+        relations = self.relations
+        return relations[0] if relations else None
+
+    def is_ready(self, relation: Optional[Relation] = None):
+        """Is this endpoint ready?"""
+        relation = relation or self._relation
+        if not relation:
+            logger.debug(f"no relation on {self._relation_name !r}: tracing not ready")
+            return False
+        if relation.data is None:
+            logger.error(f"relation data is None for {relation}")
+            return False
+        if not relation.app:
+            logger.error(f"{relation} event received but there is no relation.app")
+            return False
+        try:
+            unit = next(iter(relation.units), None)
+            if not unit:
+                return False
+            databag = dict(relation.data[unit])
+            CosAgentRequirerUnitData.load(databag)
+
+        except (json.JSONDecodeError, pydantic.ValidationError, DataValidationError):
+            logger.info(f"failed validating relation data for {relation}")
+            return False
+        return True
+
+    def get_all_endpoints(
+        self, relation: Optional[Relation] = None
+    ) -> Optional[CosAgentRequirerUnitData]:
+        """Unmarshalled relation data."""
+        relation = relation or self._relation
+        if not relation or not self.is_ready(relation):
+            return None
+        unit = next(iter(relation.units), None)
+        if not unit:
+            return None
+        return CosAgentRequirerUnitData.load(relation.data[unit])  # type: ignore
+
+    def _get_tracing_endpoint(
+        self, relation: Optional[Relation], protocol: ReceiverProtocol
+    ) -> Optional[str]:
+        unit_data = self.get_all_endpoints(relation)
+        if not unit_data:
+            return None
+        receivers: List[Receiver] = [i for i in unit_data.receivers if i.protocol.name == protocol]
+        if not receivers:
+            logger.error(f"no receiver found with protocol={protocol!r}")
+            return None
+        if len(receivers) > 1:
+            logger.error(
+                f"too many receivers with protocol={protocol!r}; using first one. Found: {receivers}"
+            )
+            return None
+
+        receiver = receivers[0]
+        return receiver.url
+
+    def get_tracing_endpoint(
+        self, protocol: ReceiverProtocol, relation: Optional[Relation] = None
+    ) -> Optional[str]:
+        """Receiver endpoint for the given protocol."""
+        endpoint = self._get_tracing_endpoint(relation or self._relation, protocol=protocol)
+        if not endpoint:
+            requested_protocols = set()
+            relations = [relation] if relation else self.relations
+            for relation in relations:
+                try:
+                    databag = CosAgentProviderUnitData.load(relation.data[self._charm.unit])
+                except DataValidationError:
+                    continue
+
+                if databag.tracing_protocols:
+                    requested_protocols.update(databag.tracing_protocols)
+
+            if protocol not in requested_protocols:
+                raise ProtocolNotRequestedError(protocol, relation)
+
+            return None
+        return endpoint
 
 
 class COSAgentDataChanged(EventBase):
@@ -558,6 +951,12 @@ class COSAgentRequirer(Object):
         if not (provider_data := self._validated_provider_data(raw)):
             return
 
+        # write enabled receivers to cos-agent relation
+        try:
+            self.update_tracing_receivers()
+        except ModelError:
+            raise
+
         # Copy data from the cos_agent relation to the peer relation, so the leader could
         # follow up.
         # Save the originating unit name, so it could be used for topology later on by the leader.
@@ -578,6 +977,37 @@ class COSAgentRequirer(Object):
         # need to emit `on.data_changed`), so we're emitting `on.data_changed` either way.
         self.on.data_changed.emit()  # pyright: ignore
 
+    def update_tracing_receivers(self):
+        """Updates the list of exposed tracing receivers in all relations."""
+        try:
+            for relation in self._charm.model.relations[self._relation_name]:
+                CosAgentRequirerUnitData(
+                    receivers=[
+                        Receiver(
+                            url=f"{self._get_tracing_receiver_url(protocol)}",
+                            protocol=ProtocolType(
+                                name=protocol,
+                                type=receiver_protocol_to_transport_protocol[protocol],
+                            ),
+                        )
+                        for protocol in self.requested_tracing_protocols()
+                    ],
+                ).dump(relation.data[self._charm.unit])
+
+        except ModelError as e:
+            # args are bytes
+            msg = e.args[0]
+            if isinstance(msg, bytes):
+                if msg.startswith(
+                    b"ERROR cannot read relation application settings: permission denied"
+                ):
+                    logger.error(
+                        f"encountered error {e} while attempting to update_relation_data."
+                        f"The relation must be gone."
+                    )
+                    return
+            raise
+
     def _validated_provider_data(self, raw) -> Optional[CosAgentProviderUnitData]:
         try:
             return CosAgentProviderUnitData(**json.loads(raw))
@@ -589,6 +1019,55 @@ class COSAgentRequirer(Object):
         """Trigger a refresh of relation data."""
         # FIXME: Figure out what we should do here
         self.on.data_changed.emit()  # pyright: ignore
+
+    def _get_requested_protocols(self, relation: Relation):
+        # Coherence check
+        units = relation.units
+        if len(units) > 1:
+            # should never happen
+            raise ValueError(
+                f"unexpected error: subordinate relation {relation} "
+                f"should have exactly one unit"
+            )
+
+        unit = next(iter(units), None)
+
+        if not unit:
+            return None
+
+        if not (raw := relation.data[unit].get(CosAgentProviderUnitData.KEY)):
+            return None
+
+        if not (provider_data := self._validated_provider_data(raw)):
+            return None
+
+        return provider_data.tracing_protocols
+
+    def requested_tracing_protocols(self):
+        """All receiver protocols that have been requested by our related apps."""
+        requested_protocols = set()
+        for relation in self._charm.model.relations[self._relation_name]:
+            try:
+                protocols = self._get_requested_protocols(relation)
+            except NotReadyError:
+                continue
+            if protocols:
+                requested_protocols.update(protocols)
+        return requested_protocols
+
+    def _get_tracing_receiver_url(self, protocol: str):
+        scheme = "http"
+        try:
+            if self._charm.cert.enabled:  # type: ignore
+                scheme = "https"
+        # not only Grafana Agent can implement cos_agent. If the charm doesn't have the `cert` attribute
+        # using our cert_handler, it won't have the `enabled` parameter. In this case, we pass and assume http.
+        except AttributeError:
+            pass
+        # the assumption is that a subordinate charm will always be accessible to its principal charm under its fqdn
+        if receiver_protocol_to_transport_protocol[protocol] == TransportProtocolType.grpc:
+            return f"{socket.getfqdn()}:{_tracing_receivers_ports[protocol]}"
+        return f"{scheme}://{socket.getfqdn()}:{_tracing_receivers_ports[protocol]}"
 
     @property
     def _remote_data(self) -> List[Tuple[CosAgentProviderUnitData, JujuTopology]]:
@@ -819,3 +1298,67 @@ class COSAgentRequirer(Object):
                 )
 
         return dashboards
+
+
+def charm_tracing_config(
+    endpoint_requirer: COSAgentProvider, cert_path: Optional[Union[Path, str]]
+) -> Tuple[Optional[str], Optional[str]]:
+    """Utility function to determine the charm_tracing config you will likely want.
+
+    If no endpoint is provided:
+     disable charm tracing.
+    If https endpoint is provided but cert_path is not found on disk:
+     disable charm tracing.
+    If https endpoint is provided and cert_path is None:
+     ERROR
+    Else:
+     proceed with charm tracing (with or without tls, as appropriate)
+
+    Usage:
+      If you are using charm_tracing >= v1.9:
+    >>> from lib.charms.tempo_k8s.v1.charm_tracing import trace_charm
+    >>> from lib.charms.tempo_k8s.v0.cos_agent import charm_tracing_config
+    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
+    >>> class MyCharm(...):
+    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
+    >>>     def __init__(self, ...):
+    >>>         self.cos_agent = COSAgentProvider(...)
+    >>>         self.my_endpoint, self.cert_path = charm_tracing_config(
+    ...             self.cos_agent, self._cert_path)
+
+      If you are using charm_tracing < v1.9:
+    >>> from lib.charms.tempo_k8s.v1.charm_tracing import trace_charm
+    >>> from lib.charms.tempo_k8s.v2.tracing import charm_tracing_config
+    >>> @trace_charm(tracing_endpoint="my_endpoint", cert_path="cert_path")
+    >>> class MyCharm(...):
+    >>>     _cert_path = "/path/to/cert/on/charm/container.crt"
+    >>>     def __init__(self, ...):
+    >>>         self.cos_agent = COSAgentProvider(...)
+    >>>         self.my_endpoint, self.cert_path = charm_tracing_config(
+    ...             self.cos_agent, self._cert_path)
+    >>>     @property
+    >>>     def my_endpoint(self):
+    >>>         return self._my_endpoint
+    >>>     @property
+    >>>     def cert_path(self):
+    >>>         return self._cert_path
+
+    """
+    if not endpoint_requirer.is_ready():
+        return None, None
+
+    endpoint = endpoint_requirer.get_tracing_endpoint("otlp_http")
+    if not endpoint:
+        return None, None
+
+    is_https = endpoint.startswith("https://")
+
+    if is_https:
+        if cert_path is None:
+            raise TracingError("Cannot send traces to an https endpoint without a certificate.")
+        if not Path(cert_path).exists():
+            # if endpoint is https BUT we don't have a server_cert yet:
+            # disable charm tracing until we do to prevent tls errors
+            return None, None
+        return endpoint, str(cert_path)
+    return endpoint, None

--- a/lib/charms/operator_libs_linux/v0/apt.py
+++ b/lib/charms/operator_libs_linux/v0/apt.py
@@ -122,7 +122,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 
 VALID_SOURCE_TYPES = ("deb", "deb-src")
@@ -837,7 +837,7 @@ def remove_package(
 
 def update() -> None:
     """Update the apt cache via `apt-get update`."""
-    subprocess.run(["apt-get", "update"], capture_output=True, check=True)
+    subprocess.run(["apt-get", "update", "--error-on=any"], capture_output=True, check=True)
 
 
 def import_key(key: str) -> str:

--- a/poetry.lock
+++ b/poetry.lock
@@ -3029,4 +3029,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "a62aa34d05150c70ea679ef8e4d7f93fa7049de6ed444453100c5e6204f293f5"
+content-hash = "5324eac94783161663f276942e7ee10f5f98c70399cc00ca3f3758952d7a2e48"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ poetry-plugin-export = "^1.8.0"
 ops = "^2.13.0"
 poetry-core = "^1.9.0"
 # tls_certificates_interface/v3/tls_certificates.py
-cryptography = "42.0.8"
+cryptography = "^42.0.8"
 jsonschema = "*"
 # pinning to avoid: https://github.com/canonical/charmcraft/issues/1722
 # We should unpin it once we have rustc 1.76+ available at build time

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -52,24 +52,45 @@ class TLSEvents(Object):
 
         self.framework.observe(getattr(self.charm.on, "config_changed"), self._on_config_changed)
 
-    def _on_certs_relation_joined(self, event: RelationJoinedEvent) -> None:
-        """Handler for `certificates_relation_joined` event."""
-        # generate unit private key if not already created by action
+    def _request_certificates(self):
+        """Request brand-new certificates."""
         if not self.charm.state.unit_server.private_key:
             self.charm.state.unit_server.update(
                 {"private-key": generate_private_key().decode("utf-8")}
             )
 
+        logger.debug(
+            "Requesting certificate for: "
+            f"host {self.charm.state.unit_server.host},"
+            f"with IP {self.charm.state.unit_server.sans.get('sans_ip', [])},"
+            f"DNS {self.charm.state.unit_server.sans.get('sans_dns', [])}"
+        )
+
         csr = generate_csr(
             private_key=self.charm.state.unit_server.private_key.encode("utf-8"),
-            subject=self.charm.state.unit_server.host,
+            subject=self.charm.state.unit_server.private_ip,
             sans_ip=self.charm.state.unit_server.sans.get("sans_ip", []),
             sans_dns=self.charm.state.unit_server.sans.get("sans_dns", []),
         )
 
         self.charm.state.unit_server.update({"csr": csr.decode("utf-8").strip()})
-
         self.certificates.request_certificate_creation(certificate_signing_request=csr)
+
+    def _remove_certificates(self):
+        """Cleanup any existing certificates."""
+        if self.charm.state.cluster.tls:
+            self.certificates.request_certificate_revocation(
+                self.charm.state.unit_server.csr.encode("utf-8")
+            )
+        self.charm.state.unit_server.update({"csr": "", "certificate": "", "ca-cert": ""})
+
+        # remove all existing keystores from the unit so we don't preserve certs
+        self.charm.tls_manager.remove_cert_files()
+
+    def _on_certs_relation_joined(self, event: RelationJoinedEvent) -> None:
+        """Handler for `certificates_relation_joined` event."""
+        # generate unit private key if not already created by action
+        self._request_certificates()
 
     def _on_certificate_available(self, event: CertificateAvailableEvent) -> None:
         """Handler for `certificates_available` event after provider updates signed certs."""
@@ -109,14 +130,12 @@ class TLSEvents(Object):
     def _on_config_changed(self, event: EventBase):
         """If system configuration (such as IP) changes, certs have to be re-issued."""
         if self.charm.state.unit_server.tls and not self.charm.tls_manager.certificate_valid():
-            self._on_certificate_expiring(event)
+            self._remove_certificates()
+            self._request_certificates()
 
     def _on_certs_relation_broken(self, _) -> None:
         """Handler for `certificates_relation_broken` event."""
-        self.charm.state.unit_server.update({"csr": "", "certificate": "", "ca-cert": ""})
-
-        # remove all existing keystores from the unit so we don't preserve certs
-        self.charm.tls_manager.remove_cert_files()
+        self._remove_certificates()
 
     def _set_tls_private_key(self, event: ActionEvent) -> None:
         """Handler for `set-tls-privat-key` event when user manually specifies private-keys for a unit."""

--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -59,6 +59,10 @@ class TLSEvents(Object):
                 {"private-key": generate_private_key().decode("utf-8")}
             )
 
+        if self.charm.state.unit_server.tls and self.charm.tls_manager.certificate_valid():
+            return
+            # OR SHOULD WE REMOVE (incl. REVOKE) AND DELETE OLD FILES (i.e. run self._remove_certificates())
+
         logger.debug(
             "Requesting certificate for: "
             f"host {self.charm.state.unit_server.host},"
@@ -135,7 +139,9 @@ class TLSEvents(Object):
 
     def _on_certs_relation_broken(self, _) -> None:
         """Handler for `certificates_relation_broken` event."""
-        self._remove_certificates()
+        # In case we have valid certificats, we keep them for smooth service function
+        if self.charm.state.unit_server.tls and not self.charm.tls_manager.certificate_valid():
+            self._remove_certificates()
 
     def _set_tls_private_key(self, event: ActionEvent) -> None:
         """Handler for `set-tls-privat-key` event when user manually specifies private-keys for a unit."""

--- a/src/managers/tls.py
+++ b/src/managers/tls.py
@@ -81,4 +81,9 @@ class TLSManager:
         except CalledProcessError as error:
             logging.error(f"Checking certificate failed: {error.output}")
             return False
+
+        logger.debug(f"Response of openssl cert decode: {response}")
+        logger.debug(
+            f"Currently recognized IP using 'gethostbyname': {self.state.unit_server.private_ip}"
+        )
         return self.state.unit_server.private_ip in response

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -11,7 +11,12 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import access_all_dashboards, get_address, get_leader_name
+from ..helpers import (
+    access_all_dashboards,
+    all_dashboards_unavailable,
+    get_address,
+    get_leader_name,
+)
 
 logger = logging.getLogger(__name__)
 

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -20,8 +20,6 @@ from ..helpers import (
 
 logger = logging.getLogger(__name__)
 
-logging.basicConfig(format="%(asctime)s %(levelname)-8s %(message)s", datefmt="%Y-%m-%d %H:%M:%S")
-
 
 CLIENT_TIMEOUT = 10
 RESTART_DELAY = 60

--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -212,7 +212,7 @@ async def network_cut_application(ops_test: OpsTest, https: bool = False):
         machine_name = await ha_helpers.get_unit_machine_name(ops_test, unit.name)
         ip = await get_address(ops_test, unit.name)
 
-        logger.info("Cutting unit {unit.name} from network...")
+        logger.info(f"Cutting unit {unit.name} from network...")
         ha_helpers.cut_unit_network(machine_name)
 
         machines.append(machine_name)
@@ -273,7 +273,7 @@ async def network_throttle_application(ops_test: OpsTest, https: bool = False):
         machine_name = await ha_helpers.get_unit_machine_name(ops_test, unit.name)
         ip = await get_address(ops_test, unit.name)
 
-        logger.info("Cutting unit {unit.name} from network...")
+        logger.info(f"Cutting unit {unit.name} from network...")
         ha_helpers.network_throttle(machine_name)
 
         machines.append(machine_name)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -7,7 +7,7 @@ import logging
 import socket
 import subprocess
 from pathlib import Path
-from subprocess import PIPE, check_output
+from subprocess import PIPE, CalledProcessError, check_output
 from typing import Dict, List, Optional
 
 import requests
@@ -15,8 +15,16 @@ import yaml
 from juju.relation import Relation
 from juju.unit import Unit
 from pytest_operator.plugin import OpsTest
-from requests.exceptions import ConnectionError
-from tenacity import Retrying, retry, stop_after_attempt, wait_fixed
+from requests.exceptions import ConnectionError, SSLError
+from tenacity import (
+    Retrying,
+    before_sleep_log,
+    retry,
+    retry_if_exception_type,
+    retry_if_result,
+    stop_after_attempt,
+    wait_fixed,
+)
 
 from core.workload import ODPaths
 
@@ -174,13 +182,7 @@ async def access_all_prometheus_exporters(ops_test: OpsTest) -> bool:
     retry=lambda x: x is False,
 )
 def dashboard_unavailable(host: str, https: bool = False) -> bool:
-    try:
-        # Normal IP address
-        socket.inet_aton(host)
-    except OSError:
-        socket.inet_pton(socket.AF_INET6, host)
-        host = f"[{host}]"
-
+    """A single OSD instance is impossible to contact."""
     protocol = "http" if not https else "https"
     url = f"{protocol}://{host}:5601/auth/login"
     arguments = {"url": url}
@@ -194,17 +196,29 @@ def dashboard_unavailable(host: str, https: bool = False) -> bool:
     return response.status_code == 503
 
 
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(15),
+    retry_error_callback=lambda _: False,
+    retry=retry_if_result(lambda x: x is False),
+)
 def all_dashboards_unavailable(ops_test: OpsTest, https: bool = False) -> bool:
-
-    if https:
-        unit = ops_test.model.applications[APP_NAME].units[0].name
-        if not get_dashboard_ca_cert(ops_test.model.name, unit):
-            logger.error(f"Couldn't retrieve host certificate for unit {unit}")
-            return False
+    """None of the OSD units are possible to contact."""
 
     unavail = True
     for unit in ops_test.model.applications[APP_NAME].units:
+
+        if https:
+            if not get_dashboard_ca_cert(ops_test.model.name, unit):
+                logger.info(f"Couldn't retrieve host certificate for unit {unit}")
+                continue
+
         host = get_private_address(ops_test.model.name, unit.name)
+
+        # We should retry until a host could be retrieved
+        if not host:
+            continue
+
         unavail = unavail and dashboard_unavailable(host, https)
         if not unavail:
             logger.error("Host {host} still available")
@@ -249,37 +263,19 @@ def access_dashboard(
     return response.status_code == 200
 
 
-def access_dashboard_https(host: str, password: str):
-    """This function should be rather replaced by a 'requests' call, if we can figure out the source of discrepancy."""
-    try:
-        curl_cmd = check_output(
-            [
-                "bash",
-                "-c",
-                'curl  -XPOST -H "Content-Type: application/json" -H "osd-xsrf: true" -H "Accept: application/json" '
-                + f"https://{host}:5601/auth/login -d "
-                + "'"
-                + '{"username":"kibanaserver","password": "'
-                + f"{password}"
-                + '"'
-                + "}' --cacert ca.pem --verbose",
-            ],
-            stderr=subprocess.STDOUT,
-            text=True,
-        )
-    except subprocess.CalledProcessError as err:
-        logger.error(f"{err}, {err.output}")
-        return False
-    return "roles" in curl_cmd
-
-
+@retry(
+    stop=stop_after_attempt(3),
+    wait=wait_fixed(15),
+    retry_error_callback=lambda _: False,
+    retry=retry_if_result(lambda x: x is False),
+)
 async def access_all_dashboards(
     ops_test: OpsTest, relation_id: int | None = None, https: bool = False, skip: list[str] = []
 ):
     """Check if all dashboard instances are accessible."""
 
     if not ops_test.model.applications[APP_NAME].units:
-        logger.debug(f"No units for application {APP_NAME}")
+        logger.error(f"No units for application {APP_NAME}")
         return False
 
     if not relation_id:
@@ -295,20 +291,19 @@ async def access_all_dashboards(
     if https:
         unit = ops_test.model.applications[APP_NAME].units[0].name
         if unit not in skip and not get_dashboard_ca_cert(ops_test.model.name, unit):
-            logger.debug(f"Couldn't retrieve host certificate for unit {unit}")
+            logger.error(f"Couldn't retrieve host certificate for unit {unit}")
             return False
 
-    function = access_dashboard if not https else access_dashboard_https
     result = True
     for unit in ops_test.model.applications[APP_NAME].units:
         if unit.name in skip:
             continue
         host = get_private_address(ops_test.model.name, unit.name)
         if not host:
-            logger.debug(f"No hostname found for {unit.name}, can't check connection.")
+            logger.error(f"No hostname found for {unit.name}, can't check connection.")
             return False
 
-        result &= function(host=host, password=dashboard_password)
+        result &= access_dashboard(host=host, password=dashboard_password, ssl=https)
         if result:
             logger.info(f"Host {unit.name}, {host} passed access check")
         else:
@@ -318,9 +313,10 @@ async def access_all_dashboards(
 
 @retry(
     stop=stop_after_attempt(5),
-    wait=wait_fixed(15),
+    wait=wait_fixed(30),
     retry_error_callback=lambda _: False,
-    retry=lambda x: x is False,
+    retry=(retry_if_result(lambda x: x is False) | retry_if_exception_type(SSLError)),
+    before_sleep=before_sleep_log(logger, logging.DEBUG),
 )
 def get_dashboard_ca_cert(model_full_name: str, unit: str):
     try:
@@ -332,6 +328,7 @@ def get_dashboard_ca_cert(model_full_name: str, unit: str):
                 f"ubuntu@{unit}:"
                 "/var/snap/opensearch-dashboards/current/etc/opensearch-dashboards/certificates/ca.pem ./",
             ],
+            timeout=30,
         )
     except subprocess.CalledProcessError as err:
         logger.error(f"{err}")
@@ -375,16 +372,32 @@ async def get_address(ops_test: OpsTest, unit_name: str) -> str:
 
 
 def get_private_address(model_full_name: str, unit: str):
-    private_ip = check_output(
-        [
-            "bash",
-            "-c",
-            f"JUJU_MODEL={model_full_name} juju ssh {unit} ip a | "
-            "grep global | grep 'inet 10.*/24' | cut -d' ' -f6 | cut -d'/' -f1",
-        ],
-        text=True,
-    )
-    return private_ip.rstrip()
+    try:
+        private_ip = check_output(
+            [
+                "bash",
+                "-c",
+                f"JUJU_MODEL={model_full_name} juju ssh {unit} ip a | "
+                "grep global | grep 'inet 10.*/24' | cut -d' ' -f6 | cut -d'/' -f1",
+            ],
+            text=True,
+        )
+    except CalledProcessError as err:
+        logger.info(f"Couldn't retrieve IP address: {str(err)}")
+        return ""
+
+    if private_ip.rstrip():
+        return private_ip.rstrip()
+
+    try:
+        info = check_output(
+            ["bash", "-c", f"JUJU_MODEL={model_full_name} juju ssh {unit} ip a "],
+            text=True,
+        )
+        logger.info(f"Couldn't retrieve IP, info is: {info}")
+    except CalledProcessError as err:
+        logger.info(f"Couldn't retrieve IP address: {str(err)}")
+        return ""
 
 
 def _get_show_unit_json(model_full_name: str, unit: str) -> Dict:

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -23,6 +23,7 @@ from .helpers import (
     count_lines_with,
     destroy_cluster,
     get_address,
+    get_file_contents,
     get_relations,
     get_unit_relation_data,
 )
@@ -126,6 +127,29 @@ async def test_dashboard_access_https(ops_test: OpsTest):
 
     assert await access_all_dashboards(ops_test, opensearch_relation.id, https=True)
     assert await access_all_prometheus_exporters(ops_test)
+
+    # Breaking the relation shouldn't impact service availabilty
+    # A new certificate is requested when the relation is joined again
+    await ops_test.juju("remove-relation", "opensearch", "opensearch-dashboards")
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
+    )
+    assert await access_all_dashboards(ops_test, opensearch_relation.id, https=True)
+    host_cert = await get_file_contents(
+        ops_test, "/var/snap/opensearch-dashboards/current/etc/opensearch-dashboards/certificates/server.pem"
+    )
+
+    # Restore relation for further tests
+    await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)
+    await ops_test.model.wait_for_idle(
+        apps=[APP_NAME, TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
+    )
+    same_host_cert = await get_file_contents(
+        ops_test, "/var/snap/opensearch-dashboards/current/etc/opensearch-dashboards/certificates/server.pem"
+    )
+    assert host_cert == same_host_cert
+    # OR THIS IS WHAT WE WANT
+    # assert host_cert != same_host_cert
 
 
 @pytest.mark.runner(["self-hosted", "linux", "X64", "jammy", "large"])

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -11,6 +11,7 @@ from ops.testing import Harness
 
 from charm import OpensearchDasboardsCharm
 from literals import CERTS_REL_NAME, CHARM_KEY, PEER
+from src.events.tls import TLSEvents
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
@@ -115,6 +116,7 @@ def test_certificates_broken(harness):
             remove_cert_files=DEFAULT,
         ),
         patch("workload.ODWorkload.configure") as workload_config,
+        patch("events.tls.TLSCertificatesRequiresV3.request_certificate_revocation"),
     ):
 
         harness.remove_relation(certs_rel_id)


### PR DESCRIPTION
When switching on TLS (halfway through the HA network cut tests) sometimes we try to access the service premature, i.e. before it's fully functional. 

This PR is an attempt to fix that.

NOTE: This PR went through a few stages since originally opened (more details on the related Jira ticket).

A change in behavior got implemented here, namely removing support for switching back-and-forth between HTTP and HTTPS. From now on, if the charm was **once** related to the `self-signed-certificates` operator, it is NOT possible to switch it back to use HTTP protocol ever again.