### PR TITLE
[DPE-4827] Release pipeline using new 'build_charm' workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,6 +3,7 @@
 name: Release to Charmhub
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -15,7 +16,7 @@ jobs:
 
   build:
     name: Build charm
-    uses: canonical/data-platform-workflows/.github/workflows/build_charm_without_cache.yaml@v16.2.1
+    uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v16.2.1
 
   release:
     name: Release charm
@@ -25,7 +26,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v16.2.1
     with:
       channel: 2/edge
-      artifact-name: ${{ needs.build.outputs.artifact-name }}
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
The release workflow was using the deprecated `build_charm_without_cache` workflow, that is not available anymore.

We should be using up-to-date versions of DP workflows, high time to getting our pipelines up-to-date 