### PR TITLE
[DPE-4828] Move to opensearch-client name

### DIFF
--- a/.github/workflows/sync_issue_to_jira.yaml
+++ b/.github/workflows/sync_issue_to_jira.yaml
@@ -13,7 +13,7 @@ jobs:
     with:
       jira-base-url: https://warthogs.atlassian.net
       jira-project-key: DPE
-      jira-component-names: mysql-router-vm
+      jira-component-names: opensearch-dashboards-vm
     secrets:
       jira-api-token: ${{ secrets.JIRA_API_TOKEN }}
       jira-user-email: ${{ secrets.JIRA_USER_EMAIL }}

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -27,7 +27,7 @@ peers:
     interface: upgrade
 
 requires:
-  opensearch_client:
+  opensearch-client:
     interface: opensearch_client
     limit: 1
     optional: true

--- a/src/literals.py
+++ b/src/literals.py
@@ -10,7 +10,7 @@ SUBSTRATE = "vm"
 CHARM_KEY = "opensearch-dashboards"
 
 PEER = "dashboard_peers"
-OPENSEARCH_REL_NAME = "opensearch_client"
+OPENSEARCH_REL_NAME = "opensearch-client"
 CERTS_REL_NAME = "certificates"
 DASHBOARD_INDEX = ".opensearch-dashboards"
 DASHBOARD_USER = "kibanaserver"

--- a/tests/integration/application-charm/metadata.yaml
+++ b/tests/integration/application-charm/metadata.yaml
@@ -9,5 +9,5 @@ series:
   - jammy
 
 requires:
-  opensearch_client:
+  opensearch-client:
     interface: opensearch_client

--- a/tests/integration/application-charm/src/charm.py
+++ b/tests/integration/application-charm/src/charm.py
@@ -35,7 +35,7 @@ class ApplicationCharm(CharmBase):
         self.framework.observe(self.on.update_status, self._on_update_status)
 
         # `albums` index is used in integration test
-        self.opensearch = OpenSearchRequires(self, "opensearch_client", "albums", "")
+        self.opensearch = OpenSearchRequires(self, "opensearch-client", "albums", "")
 
         self.framework.observe(self.opensearch.on.index_created, self._on_authentication_updated)
         self.framework.observe(
@@ -47,7 +47,7 @@ class ApplicationCharm(CharmBase):
             self.on.run_dashboards_request_action, self._on_run_dashboards_request_action
         )
 
-        self.relations = {"opensearch_client": self.opensearch}
+        self.relations = {"opensearch-client": self.opensearch}
 
     def _on_update_status(self, _) -> None:
         """Health check for index connection."""

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -211,7 +211,7 @@ async def access_all_dashboards(
         return False
 
     if not relation_id:
-        relation_id = get_relation(ops_test, "opensearch_client").id
+        relation_id = get_relation(ops_test, "opensearch-client").id
 
     dashboard_credentials = await get_secret_by_label(
         ops_test, f"opensearch-client.{relation_id}.user.secret"

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -64,7 +64,7 @@ def get_relations(ops_test: OpsTest, name: str, app_name: str = APP_NAME) -> lis
     return results
 
 
-def get_relation(ops_test: OpsTest, relation: str = "opensearch_client"):
+def get_relation(ops_test: OpsTest, relation: str = "opensearch-client"):
     return get_relations(ops_test, relation)[0]
 
 

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -33,7 +33,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 OPENSEARCH_APP_NAME = "opensearch"
-OPENSEARCH_RELATION_NAME = "opensearch_client"
+OPENSEARCH_RELATION_NAME = "opensearch-client"
 OPENSEARCH_CONFIG = {
     "logging-config": "<root>=INFO;unit=DEBUG",
     "cloudinit-userdata": """postruncmd:


### PR DESCRIPTION
Get the same endpoint name for client: `opensearch-client`.

Closes #85 