### PR TITLE
[DONT MERGE] Debug constant mock

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -286,6 +286,8 @@ class OpensearchDasboardsCharm(CharmBase):
         # 'Service unavailable' until the next 'update-status' hook execution
         start_time = time.time()
         unit_healthy, _ = self.health_manager.unit_healthy()
+        import pdb; pdb.set_trace()
+
         while not unit_healthy and time.time() - start_time < SERVICE_AVAILABLE_TIMEOUT:
             time.sleep(5)
             unit_healthy, _ = self.health_manager.unit_healthy()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -21,7 +21,6 @@ from src.literals import (
     MSG_INCOMPATIBLE_UPGRADE,
     MSG_STATUS_ERROR,
     MSG_STATUS_UNHEALTHY,
-    # SERVICE_AVAILABLE_TIMEOUT,
 )
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
Leaving all "desperate" attetmtps visible, highlighting the problem.

```
tox run -e unit -- -k test_restart_sleep_with_timeout_if_service_down
```
> SERVICE_AVAILABLE_TIMEOUT should be 15 yet it's still 90

I must be overlooking something banal... Or is there "unexpected" `Harness` magic I'm not taking into account...?