### PR TITLE
Fix branch release on CI

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ name: Release to Charmhub
 on:
   push:
     branches:
-      - main
+      - 2/edge
 
 jobs:
   ci-tests:


### PR DESCRIPTION
Currently, the CI only releases new versions if we have a push to the `main` branch. However, `2/edge` is the new default.