### PR TITLE
[OpenSearch] Add config profile=testing

### DIFF
--- a/tests/integration/ha/test_network_cut.py
+++ b/tests/integration/ha/test_network_cut.py
@@ -12,6 +12,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
+    CONFIG_OPTS,
     access_all_dashboards,
     all_dashboards_unavailable,
     get_address,
@@ -61,7 +62,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Opensearch
     await ops_test.model.set_config(OPENSEARCH_CONFIG)
     # NOTE: can't access 2/stable from the tests, only 'edge' available
-    await ops_test.model.deploy(OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB)
+    await ops_test.model.deploy(
+        OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB, config=CONFIG_OPTS
+    )
 
     config = {"ca-common-name": "CN_CA"}
     await ops_test.model.deploy(TLS_CERT_APP_NAME, channel="stable", config=config)

--- a/tests/integration/ha/test_scaling.py
+++ b/tests/integration/ha/test_scaling.py
@@ -9,7 +9,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from ..helpers import access_all_dashboards, get_relation
+from ..helpers import CONFIG_OPTS, access_all_dashboards, get_relation
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     # Opensearch
     await ops_test.model.set_config(OPENSEARCH_CONFIG)
     # NOTE: can't access 2/stable from the tests, only 'edge' available
-    await ops_test.model.deploy(OPENSEARCH_APP_NAME, channel="2/edge", num_units=2)
+    await ops_test.model.deploy(
+        OPENSEARCH_APP_NAME, channel="2/edge", num_units=2, config=CONFIG_OPTS
+    )
 
     config = {"ca-common-name": "CN_CA"}
     await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config)

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -32,6 +32,7 @@ METADATA = yaml.safe_load(Path("./metadata.yaml").read_text())
 APP_NAME = METADATA["name"]
 OPENSEARCH_APP_NAME = "opensearch"
 SERIES = "jammy"
+CONFIG_OPTS = {"profile": "testing"}
 
 OPENSEARCH_APP_NAME = "opensearch"
 OPENSEARCH_RELATION_NAME = "opensearch-client"

--- a/tests/integration/spaces/test_wrong_etc_hosts.py
+++ b/tests/integration/spaces/test_wrong_etc_hosts.py
@@ -10,6 +10,7 @@ from pytest_operator.plugin import OpsTest
 
 from ..helpers import (
     APP_NAME,
+    CONFIG_OPTS,
     OPENSEARCH_APP_NAME,
     SERIES,
     TLS_CERTIFICATES_APP_NAME,
@@ -89,6 +90,7 @@ async def test_build_and_deploy(ops_test: OpsTest, lxd_spaces) -> None:
         constraints="spaces=alpha,client,cluster,backup",
         bind={"": "cluster"},
         num_units=3,
+        config=CONFIG_OPTS,
     )
     await ops_test.model.integrate(OPENSEARCH_APP_NAME, TLS_CERTIFICATES_APP_NAME)
     await ops_test.model.integrate(OPENSEARCH_APP_NAME, APP_NAME)

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -14,6 +14,7 @@ import yaml
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (
+    CONFIG_OPTS,
     DASHBOARD_QUERY_PARAMS,
     SERIES,
     access_all_dashboards,
@@ -71,7 +72,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     config = {"ca-common-name": "CN_CA"}
     await asyncio.gather(
         ops_test.model.deploy(COS_AGENT_APP_NAME, series=SERIES),
-        ops_test.model.deploy(OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB),
+        ops_test.model.deploy(
+            OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB, config=CONFIG_OPTS
+        ),
         ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config),
         ops_test.model.deploy(application_charm_build, application_name=DB_CLIENT_APP_NAME),
     )
@@ -354,7 +357,9 @@ async def test_restore_opensearch_restores_osd(ops_test: OpsTest):
     logger.info("Destroying and restoring the Opensearch cluster")
     await destroy_cluster(ops_test, app=OPENSEARCH_APP_NAME)
 
-    await ops_test.model.deploy(OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB),
+    await ops_test.model.deploy(
+        OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB, config=CONFIG_OPTS
+    ),
     await ops_test.model.integrate(OPENSEARCH_APP_NAME, TLS_CERTIFICATES_APP_NAME)
     async with ops_test.fast_forward("30s"):
         await ops_test.model.wait_for_idle(apps=[OPENSEARCH_APP_NAME], status="blocked")

--- a/tests/integration/test_upgrade.py
+++ b/tests/integration/test_upgrade.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from pytest_operator.plugin import OpsTest
 
-from .helpers import access_all_dashboards, get_app_relation_data
+from .helpers import CONFIG_OPTS, access_all_dashboards, get_app_relation_data
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,9 @@ async def test_build_and_deploy(ops_test: OpsTest):
     pytest.charm = await ops_test.build_charm(".")
     await ops_test.model.deploy(pytest.charm, application_name=APP_NAME, num_units=NUM_UNITS_APP)
     await ops_test.model.set_config(OPENSEARCH_CONFIG)
-    await ops_test.model.deploy(OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB)
+    await ops_test.model.deploy(
+        OPENSEARCH_APP_NAME, channel="2/edge", num_units=NUM_UNITS_DB, config=CONFIG_OPTS
+    )
 
     config = {"ca-common-name": "CN_CA"}
     await ops_test.model.deploy(TLS_CERTIFICATES_APP_NAME, channel="stable", config=config)


### PR DESCRIPTION
OpenSearch has a new feature: `profile`, which enables to select different types of settings for your cluster and runs by default as "production". However, that breaks CI as we run LXD clusters within a single runner.

This PR decreases the RAM consumption: `profile=testing`.