### PR TITLE
Remove get-password

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,13 +1,6 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-get-password:
-  description: Returns the Opensearch Dashboards user password
-  params:
-    username:
-      type: string
-      description: The username, the default value 'monitor'.
-
 pre-upgrade-check:
   description: Run necessary pre-upgrade checks before executing a charm upgrade.
 


### PR DESCRIPTION
The `get-password` action makes no sense in opensearch dashboards as users are managed in opensearch. Currently, this action is handled nowhere in the charm.

More information: https://discourse.charmhub.io/t/charmed-opensearch-dashboards-tutorial-access/14123