### PR TITLE
[DPE-5909][DPE-4308] Support secure_authentication toggle:

### DIFF
--- a/src/managers/config.py
+++ b/src/managers/config.py
@@ -25,7 +25,6 @@ DEFAULT_PROPERTIES = {
     "opensearch_security.readonly_mode.roles": ["kibana_read_only"],
     "server.ssl.enabled": False,
     "opensearch_security.cookie.secure": False,
-    "server.ssl.supportedProtocols": ["TLSv1.2"],  # In tandem with current OpenSearch
 }
 
 # Overrides the DEFAULT_PROPERTIES if we have TLS enabled

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -32,8 +32,6 @@ opensearch_security.readonly_mode.roles:
 path.data: /var/snap/opensearch-dashboards/common/var/lib/opensearch-dashboards
 server.host: {ip}
 server.ssl.enabled: false
-server.ssl.supportedProtocols:
-- TLSv1.2
 """
 
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -18,17 +18,23 @@ CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
 METADATA = str(yaml.safe_load(Path("./metadata.yaml").read_text()))
 
-DEFAULT_CONF = """
-opensearch.ssl.verificationMode: full
-opensearch.requestHeadersWhitelist: [authorization, securitytenant]
+DEFAULT_CONF = """logging.verbose: true
+opensearch.requestHeadersWhitelist:
+- authorization
+- securitytenant
+opensearch_security.cookie.secure: false
 opensearch_security.multitenancy.enabled: true
-opensearch_security.multitenancy.tenants.preferred: [Private, Global]
-opensearch_security.readonly_mode.roles: [kibana_read_only]
-opensearch_security.cookie.secure: true
-
-server.host: '{ip}'
-logging.verbose: true
-path.data: /var/snap/opensearch-dashboards/common/var/lib/opensearch-dashboards"""
+opensearch_security.multitenancy.tenants.preferred:
+- Private
+- Global
+opensearch_security.readonly_mode.roles:
+- kibana_read_only
+path.data: /var/snap/opensearch-dashboards/common/var/lib/opensearch-dashboards
+server.host: {ip}
+server.ssl.enabled: false
+server.ssl.supportedProtocols:
+- TLSv1.2
+"""
 
 
 @pytest.fixture
@@ -46,23 +52,12 @@ def harness():
 
 
 def test_log_level_changed(harness):
-    with (
-        patch(
-            "managers.config.ConfigManager.build_static_properties",
-            return_value=["log_level=logging.verbose"],
-        ),
-        patch(
-            "managers.config.ConfigManager.static_properties",
-            return_value="log_level=logging.silent",
-        ),
-        patch("managers.config.ConfigManager.set_dashboard_properties") as set_props,
-    ):
+    with (patch("managers.config.ConfigManager.set_dashboard_properties") as set_props,):
         harness.charm.config_manager.config_changed()
         set_props.assert_called_once()
 
     with (
-        patch("workload.ODWorkload.read", return_value=["log_level=logging.silent"]),
-        patch("managers.config.ConfigManager.current_env", return_value=["log_level"]),
+        patch("workload.ODWorkload.read", return_value=["log_level: logging.silent"]),
         patch("workload.ODWorkload.write") as write,
     ):
         assert harness.charm.config_manager.config_changed()
@@ -85,19 +80,4 @@ def test_tls_enabled(harness):
             label=f"{PEER}.opensearch-dashboards.unit",
         )
 
-    assert "server.ssl.enabled: true" in harness.charm.config_manager.dashboard_properties
-
-
-# def test_properties_tls_uses_passwords(harness):
-#     with harness.hooks_disabled():
-#         harness.update_relation_data(
-#             harness.charm.state.peer_relation.id, CHARM_KEY, {"tls": "enabled"}
-#         )
-#         harness.update_relation_data(
-#             harness.charm.state.peer_relation.id,
-#             f"{CHARM_KEY}/0",
-#             {"keystore-password": "mellon", "truststore-password": "friend"},
-#         )
-#
-#     assert "ssl.keyStore.password=mellon" in harness.charm.config_manager.dashboard_properties
-#     assert "ssl.trustStore.password=friend" in harness.charm.config_manager.dashboard_properties
+    assert harness.charm.config_manager.dashboard_properties.get("server.ssl.enabled") is True


### PR DESCRIPTION
The current charm enforces secure_authentication cookie to True, which means we cannot effectively use opensearch-dashboards without TLS. This change extends the current charm to instead toggle the secure_authentication and other TLS-related options accordingly.

This change also reformats config_manager.py to load and manage configuration as a dict instead of a list.

Closes #129, #35 