### PR TITLE
The `opensearch-client` is not optional

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -30,7 +30,6 @@ requires:
   opensearch-client:
     interface: opensearch_client
     limit: 1
-    optional: true
   certificates:
     interface: tls-certificates
     limit: 1


### PR DESCRIPTION
We cannot deploy opensearch-dashboard without `opensearch-client`. Even if this field is not considered, it still may be confusing for a given user.