### PR TITLE
Add promtool check and test in the CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,19 +28,19 @@ jobs:
       - name: Run linters
         run: tox run -e lint
 
-  lib-check:               
-    name: Check libraries  
+  lib-check:
+    name: Check libraries
     runs-on: ubuntu-latest
-    timeout-minutes: 5     
-    steps:                 
-      - name: Checkout     
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0   
+          fetch-depth: 0
       - run: |
           # Workaround for https://github.com/canonical/charmcraft/issues/1389#issuecomment-1880921728
-          touch requirements.txt          
-      - name: Check libs   
+          touch requirements.txt
+      - name: Check libs
         uses: canonical/charming-actions/check-libraries@2.6.0
         with:
           credentials: ${{ secrets.CHARMHUB_TOKEN }}
@@ -61,6 +61,9 @@ jobs:
           pipx install poetry
       - name: Run tests
         run: tox run -e unit
+
+  promtool:
+    uses: ./.github/workflows/test_prometheus_rules.yaml
 
   terraform-test:
     name: Terraform - Lint and Simple Deployment
@@ -129,13 +132,13 @@ jobs:
           # All runs
           - agent: 3.5.3 # renovate: juju-agent-pin-minor
             allure_report: true
-          
+
           # This runs only on scheduled runs, DPW 21 specifics (scheduled + 3.6/X)
           - snap_channel: 3.6/beta
             allure_report: false
-    
+
     name: Integration test charm | ${{ matrix.juju.agent || matrix.juju.snap_channel }}
-    
+
     needs:
       - lint
       - unit-test

--- a/.github/workflows/test_prometheus_rules.yaml
+++ b/.github/workflows/test_prometheus_rules.yaml
@@ -3,12 +3,6 @@ name: Test prometheus rules
 on:
   workflow_call:
   workflow_dispatch:
-  pull_request:
-    types: [opened, synchronize, reopened]
-    branches: [main]
-    paths-ignore:
-      - "**.md"
-      - "**.rst"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/test_prometheus_rules.yaml
+++ b/.github/workflows/test_prometheus_rules.yaml
@@ -1,0 +1,34 @@
+name: Test prometheus rules
+
+on:
+  workflow_call:
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    branches: [main]
+    paths-ignore:
+      - "**.md"
+      - "**.rst"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  promtool:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+
+      # prometheus snap includes promtool
+      - name: Install prometheus snap
+        run: sudo snap install prometheus
+
+      - name: Check validity of prometheus alert rules
+        run: |
+          promtool check rules src/alert_rules/prometheus/*.yaml
+
+      - name: Run unit tests for prometheus alert rules
+        run: |
+          promtool test rules tests/unit/test_alert_rules/*.yaml

--- a/tests/unit/test_alert_rules/test_opensearch_dashboards_rules.yaml
+++ b/tests/unit/test_alert_rules/test_opensearch_dashboards_rules.yaml
@@ -1,0 +1,20 @@
+rule_files:
+  - ../../../src/alert_rules/prometheus/prometheus_alerts.yaml
+
+evaluation_interval: 1m
+
+tests:
+  - interval: 1m
+    input_series:
+      - series: 'up{juju_unit="opensearch-dashboards/1"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: OpenSearchDashboardsScrapeFailed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              juju_unit: opensearch-dashboards/1
+            exp_annotations:
+              message: "Scrape on opensearch-dashboards/1 failed. Ensure that the OpenSearch Dashboards systemd service is healthy."
+              summary: "OpenSearch exporter scrape failed"


### PR DESCRIPTION
This PR adds the check and test of Prometheus rules. Because the exporter is going to change and also the metrics/rules, the only unit test covered is for if the scrape is up.

When the new exporter is used, then the new rules and unit tests will be implemented.

## How to test this PR

1. Install the prometheus snap:
```shell
sudo snap install prometheus
```

2. Run to check if the rules file is valid:
```shell
promtool check rules src/alert_rules/prometheus/*.yaml
```

3. Run the unit tests:
```
promtool test rules tests/unit/test_alert_rules/*.yaml
```