### PR TITLE
[DPE-6217] Remove channel + revision mentions

### DIFF
--- a/src/workload.py
+++ b/src/workload.py
@@ -134,7 +134,6 @@ class ODWorkload(WorkloadBase):
             dashboards.ensure(
                 snap.SnapState.Present,
                 revision=OPENSEARCH_DASHBOARDS_SNAP_REVISION,
-                channel="edge",
             )
 
             self.dashboards = dashboards


### PR DESCRIPTION
Currently, we are deviating from the standard behavior at install, i.e. only specifying the revision number of the snap. This PR fixes this issue by removing the channel reference.

Closes: #144 