### PR TITLE
Add new Prometheus Rules using the python exporter

### DIFF
--- a/src/alert_rules/prometheus/prometheus_alerts.yaml
+++ b/src/alert_rules/prometheus/prometheus_alerts.yaml
@@ -1,43 +1,66 @@
-"groups":
-- "name": "opensearch_dashboards.alerts"
-  "rules":
+groups:
+- name: opensearch_dashboards.alerts
+  rules:
 
-  - "alert": "OpenSearchDashboardsScrapeFailed"
-    "annotations":
-      "message": "Scrape on {{ $labels.juju_unit }} failed. Ensure that the OpenSearch Dashboards systemd service is healthy."
-      "summary": "OpenSearch exporter scrape failed"
-    "expr": |
-      up < 1
-    "for": "5m"
-    "labels":
-      "severity": "critical"
+  - alert: OpenSearchDashboardsScrapeFailed
+    annotations:
+      description: Scrape on {{ $labels.juju_unit }} failed. Ensure that the OpenSearch Dashboards systemd service is healthy.
+      summary: "OpenSearch exporter scrape failed"
+    expr: up < 1
+    for: 5m
+    labels:
+      severity: critical
 
-  - "alert": "OpenSearchDashboardsNotHealthy"
-    "annotations":
-      "message": "Server status is not green. The server may be down, it may have lost connection to Opensearch, or may suffer of partial unavailability."
-      "summary": "Server health status is green"
-    "expr": |
-      absent(kibana_status) == 1 or kibana_status > 0
-    "for": "2m"
-    "labels":
-      "severity": "critical"
+  - alert: OpenSearchDashboardsRed
+    annotations:
+      description: "Dashboards status is red. The server may be down, it may have lost connection to Opensearch, or may suffer of partial unavailability."
+      summary: Server health status is red or plugins are down
+    expr: opensearch_dashboards_status == 2
+    for: 2m
+    labels:
+      severity: critical
 
-  - "alert": "OpenSearchDashboardsLongResponseTime"
-    "annotations":
-      "message": "The server is up and responsive, however with a high latency."
-      "summary": "High response time"
-    "expr": |
-      kibana_response_average > 200
-    "for": "2m"
-    "labels":
-      "severity": "critical"
+  - alert: OpenSearchDashboardsYellow
+    annotations:
+      description: Dashboards status is yellow. Plugins might be degraded or shards may be relocating or initializing.
+      summary: Dashboard health status is yellow
+    expr: opensearch_dashboards_status == 1
+    for: 10m
+    labels:
+      severity: warning
 
-  - "alert": "OpenSearchDashboardsNoOpensearchConnection"
-    "annotations":
-      "message": "Connection to the Opensearch backend is lost."
-      "summary": "No connection to Opensearch"
-    "expr": |
-      absent(kibana_core_es_status) == 1 or kibana_core_es_status > 0
-    "for": "2m"
-    "labels":
-      "severity": "critical"
+  - alert: OpenSearchDashboardsPluginRed
+    annotations:
+      description: "Dashboards {{ $labels.id }} status is red: {{ $labels.message }}"
+      summary: Dashboards plugin status is red
+    expr: opensearch_dashboards_statuses == 2
+    for: "2m"
+    labels:
+      severity: critical
+
+  - alert: OpenSearchDashboardsPluginYellow
+    annotations:
+      description: "Dashboards {{ $labels.id }} status is yellow: {{ $labels.message }}"
+      summary: Dashboards plugin status is yellow
+    expr: opensearch_dashboards_statuses == 1
+    for: "10m"
+    labels:
+      severity: warning
+
+  - alert: OpenSearchDashboardsNoMetrics
+    annotations:
+      description: Exporter failed to collect status metrics. Dashboards may be down or user and password may be invalid. Check the exporter logs.
+      summary: No metrics collected.
+    expr: opensearch_dashboards_up == 0
+    for: 2m
+    labels:
+      severity: critical
+
+  - alert: OpenSearchDashboardsLongResponseTime
+    annotations:
+      description: The server is up and responsive, however with a high latency.
+      summary: High response time
+    expr: opensearch_dashboards_resp_time_avg > 200
+    for: "2m"
+    labels:
+      severity: "critical"

--- a/src/grafana_dashboards/dashboard.json
+++ b/src/grafana_dashboards/dashboard.json
@@ -24,7 +24,6 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
-  "id": 1,
   "links": [],
   "liveNow": false,
   "panels": [
@@ -94,7 +93,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -102,7 +101,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_millis_uptime/1000/60/60/60",
+          "expr": "opensearch_dashboards_up_time{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1000 / 60 / 60 / 60",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -162,7 +161,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -171,7 +170,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "(kibana_heap_used_in_bytes/kibana_heap_max_in_bytes)*100",
+          "expr": "(opensearch_dashboards_heap_used{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / opensearch_dashboards_heap_size{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}) * 100",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -233,7 +232,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -241,7 +240,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "(kibana_os_memory_used_in_bytes/kibana_os_memory_max_in_bytes)*100",
+          "expr": "(opensearch_dashboards_os_mem_used{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / opensearch_dashboards_os_mem_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}) * 100",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -260,7 +259,7 @@
           "color": {
             "mode": "thresholds"
           },
-          "decimals": 3,
+          "decimals": 2,
           "mappings": [],
           "max": 100,
           "min": 0,
@@ -302,7 +301,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -310,13 +309,13 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "((kibana_resident_set_size_in_bytes/1024/1024)/(kibana_os_memory_max_in_bytes/1024/1024))*100",
+          "expr": "((opensearch_dashboards_re_set_size{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1024 / 1024) / (opensearch_dashboards_os_mem_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1024 / 1024)) * 100",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
         }
       ],
-      "title": "Resident Set Size",
+      "title": "RSS to Total Memory Ratio",
       "type": "stat"
     },
     {
@@ -369,7 +368,7 @@
         },
         "textMode": "value"
       },
-      "pluginVersion": "9.4.7",
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -377,7 +376,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_concurrent_connections",
+          "expr": "opensearch_dashboards_current_connections{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -394,54 +393,77 @@
       "fieldConfig": {
         "defaults": {
           "color": {
-            "mode": "thresholds"
+            "mode": "fixed",
+            "seriesBy": "last"
           },
           "custom": {
-            "fillOpacity": 78,
-            "lineWidth": 0,
-            "spanNulls": false
+            "axisCenteredZero": true,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "axisSoftMax": 2,
+            "axisSoftMin": -1,
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 4,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
           },
-          "decimals": 2,
+          "decimals": 0,
           "mappings": [
             {
               "options": {
                 "0": {
-                  "color": "dark-red",
-                  "index": 3,
-                  "text": "Critical"
+                  "color": "green",
+                  "index": 0,
+                  "text": "Green"
                 },
                 "1": {
-                  "color": "dark-green",
-                  "index": 0,
-                  "text": "Available"
-                },
-                "0.25": {
-                  "color": "dark-orange",
-                  "index": 2,
-                  "text": "Unavailable"
-                },
-                "0.5": {
-                  "color": "dark-yellow",
+                  "color": "yellow",
                   "index": 1,
-                  "text": "Degraded"
+                  "text": "Yellow"
+                },
+                "2": {
+                  "color": "red",
+                  "index": 2,
+                  "text": "Red"
+                },
+                "-1": {
+                  "color": "purple",
+                  "index": 3,
+                  "text": "Unknown"
                 }
               },
               "type": "value"
             }
           ],
-          "max": 1,
-          "min": 0,
-          "noValue": "0",
+          "max": 2,
+          "min": -1,
           "thresholds": {
-            "mode": "percentage",
+            "mode": "absolute",
             "steps": [
               {
-                "color": "dark-red",
+                "color": "green",
                 "value": null
-              },
-              {
-                "color": "dark-green",
-                "value": 80
               }
             ]
           }
@@ -449,64 +471,107 @@
         "overrides": [
           {
             "matcher": {
-              "id": "byName",
-              "options": "{__name__=\"kibana_status\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
+              "id": "byFrameRefID",
+              "options": "A"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "Overall Status"
+                "value": "Overall"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "B"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "Saved Objects"
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "{__name__=\"kibana_core_es_status\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
+              "options": "Saved Objects"
             },
             "properties": [
               {
-                "id": "displayName",
-                "value": "Elasticsearch Status"
+                "id": "color",
+                "value": {
+                  "fixedColor": "blue",
+                  "mode": "fixed"
+                }
               }
             ]
           },
           {
             "matcher": {
               "id": "byName",
-              "options": "{__name__=\"kibana_core_savedobjects_status\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
+              "options": "Overall"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "#d615d4",
+                  "mode": "fixed"
+                }
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byFrameRefID",
+              "options": "C"
             },
             "properties": [
               {
                 "id": "displayName",
-                "value": "SavedObjects Status"
+                "value": "OpenSearch"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "OpenSearch"
+            },
+            "properties": [
+              {
+                "id": "color",
+                "value": {
+                  "fixedColor": "orange",
+                  "mode": "fixed"
+                }
               }
             ]
           }
         ]
       },
       "gridPos": {
-        "h": 4,
-        "w": 8,
+        "h": 6,
+        "w": 7,
         "x": 16,
         "y": 1
       },
-      "id": 10,
+      "id": 28,
       "options": {
-        "alignValue": "left",
         "legend": {
+          "calcs": [],
           "displayMode": "list",
           "placement": "bottom",
-          "showLegend": true
+          "showLegend": false
         },
-        "mergeValues": true,
-        "rowHeight": 0.91,
-        "showValue": "auto",
         "tooltip": {
           "mode": "single",
           "sort": "none"
         }
       },
+      "pluginVersion": "9.5.3",
       "targets": [
         {
           "datasource": {
@@ -514,7 +579,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_status",
+          "expr": "opensearch_dashboards_status{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "legendFormat": "__auto",
           "range": true,
           "refId": "A"
@@ -524,8 +589,8 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "editorMode": "code",
-          "expr": "kibana_core_es_status",
+          "editorMode": "builder",
+          "expr": "opensearch_dashboards_statuses{id=~\"core:savedObjects.*\"}",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -536,8 +601,8 @@
             "type": "prometheus",
             "uid": "${prometheusds}"
           },
-          "editorMode": "code",
-          "expr": "kibana_core_savedobjects_status",
+          "editorMode": "builder",
+          "expr": "opensearch_dashboards_statuses{id=~\"core:opensearch.*\"}",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -545,7 +610,7 @@
         }
       ],
       "title": "Overall Status",
-      "type": "state-timeline"
+      "type": "timeseries"
     },
     {
       "collapsed": false,
@@ -553,7 +618,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 7
       },
       "id": 17,
       "panels": [],
@@ -626,7 +691,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 6
+        "y": 8
       },
       "id": 2,
       "options": {
@@ -653,7 +718,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_heap_max_in_bytes/1024/1024",
+          "expr": "opensearch_dashboards_heap_size{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1024 / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -666,7 +731,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_heap_used_in_bytes/1024/1024",
+          "expr": "opensearch_dashboards_heap_used{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1024 / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -674,7 +739,7 @@
           "refId": "B"
         }
       ],
-      "title": "Kibana Heap Usage",
+      "title": "OpenSearch Dashboards Heap Usage",
       "transformations": [],
       "type": "timeseries"
     },
@@ -744,7 +809,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 6
+        "y": 8
       },
       "id": 23,
       "options": {
@@ -771,7 +836,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_os_memory_max_in_bytes/1024/1024",
+          "expr": "opensearch_dashboards_os_mem_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1024 / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -784,7 +849,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_os_memory_used_in_bytes/1024/1024",
+          "expr": "opensearch_dashboards_os_mem_used{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"} / 1024 / 1024",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -860,7 +925,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "{__name__=\"kibana_os_load_1m\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
+              "options": "{__name__=\"opensearch_dashboards_load_1m\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
             },
             "properties": [
               {
@@ -872,7 +937,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "{__name__=\"kibana_os_load_5m\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
+              "options": "{__name__=\"opensearch_dashboards_load_5m\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
             },
             "properties": [
               {
@@ -884,7 +949,7 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "{__name__=\"kibana_os_load_15m\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
+              "options": "{__name__=\"opensearch_dashboards_load_15m\", instance=\"172.17.0.1:9684\", job=\"local_kibana\"}"
             },
             "properties": [
               {
@@ -899,7 +964,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 6
+        "y": 8
       },
       "id": 15,
       "options": {
@@ -926,7 +991,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_os_load_1m",
+          "expr": "opensearch_dashboards_load_1m{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -939,7 +1004,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_os_load_5m",
+          "expr": "opensearch_dashboards_load_5m{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -952,7 +1017,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_os_load_15m",
+          "expr": "opensearch_dashboards_load_15m{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -969,7 +1034,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 12
+        "y": 14
       },
       "id": 22,
       "panels": [],
@@ -1039,7 +1104,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 13
+        "y": 15
       },
       "id": 20,
       "options": {
@@ -1066,7 +1131,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_concurrent_connections",
+          "expr": "opensearch_dashboards_current_connections{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -1142,7 +1207,7 @@
         "h": 6,
         "w": 6,
         "x": 6,
-        "y": 13
+        "y": 15
       },
       "id": 25,
       "options": {
@@ -1169,7 +1234,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_requests_total",
+          "expr": "opensearch_dashboards_req_total{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -1182,7 +1247,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_requests_disconnects",
+          "expr": "opensearch_dashboards_req_disconnects{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1256,7 +1321,7 @@
         "h": 6,
         "w": 6,
         "x": 12,
-        "y": 13
+        "y": 15
       },
       "id": 26,
       "options": {
@@ -1283,7 +1348,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_response_average",
+          "expr": "opensearch_dashboards_resp_time_avg{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -1296,7 +1361,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_response_max",
+          "expr": "opensearch_dashboards_resp_time_max{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "legendFormat": "__auto",
           "range": true,
@@ -1370,7 +1435,7 @@
         "h": 6,
         "w": 6,
         "x": 18,
-        "y": 13
+        "y": 15
       },
       "id": 27,
       "options": {
@@ -1397,7 +1462,7 @@
             "uid": "${prometheusds}"
           },
           "editorMode": "code",
-          "expr": "kibana_event_loop_delay",
+          "expr": "opensearch_dashboards_event_loop_delay{juju_application=~\"$juju_application\",juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_unit=~\"$juju_unit\"}",
           "hide": false,
           "interval": "",
           "legendFormat": "__auto",
@@ -1415,10 +1480,171 @@
   "schemaVersion": 38,
   "style": "dark",
   "tags": [
-    "kibana"
+    "OpenSearch Dashboards"
   ],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Loki datasource",
+        "multi": true,
+        "name": "lokids",
+        "options": [],
+        "query": "loki",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "hide": 0,
+        "includeAll": true,
+        "label": "Prometheus datasource",
+        "multi": true,
+        "name": "prometheusds",
+        "options": [],
+        "query": "prometheus",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju unit",
+        "multi": true,
+        "name": "juju_unit",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\",juju_application=~\"$juju_application\"},juju_unit)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju application",
+        "multi": true,
+        "name": "juju_application",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\",juju_model_uuid=~\"$juju_model_uuid\"},juju_application)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model uuid",
+        "multi": true,
+        "name": "juju_model_uuid",
+        "options": [],
+        "query": {
+          "query": "label_values(up{juju_model=~\"$juju_model\"},juju_model_uuid)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      },
+      {
+        "allValue": ".*",
+        "current": {
+          "selected": false,
+          "text": "All",
+          "value": "$__all"
+        },
+        "datasource": {
+          "uid": "${prometheusds}"
+        },
+        "definition": "label_values(up,juju_model)",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Juju model",
+        "multi": true,
+        "name": "juju_model",
+        "options": [],
+        "query": {
+          "query": "label_values(up,juju_model)",
+          "refId": "StandardVariableQuery"
+        },
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-12h",
@@ -1427,7 +1653,7 @@
   "timepicker": {},
   "timezone": "browser",
   "title": "Charmed Opensearch Dashboards",
-  "uid": "w7fRRIPVz",
-  "version": 14,
+  "uid": "df1e16cfa7d31daf0fd9df185d6fdf5730d3a5b4",
+  "version": 1,
   "weekStart": ""
 }

--- a/src/literals.py
+++ b/src/literals.py
@@ -4,7 +4,7 @@
 
 """Collection of global literals for the charm."""
 
-OPENSEARCH_DASHBOARDS_SNAP_REVISION = "25"
+OPENSEARCH_DASHBOARDS_SNAP_REVISION = "26"
 
 SUBSTRATE = "vm"
 CHARM_KEY = "opensearch-dashboards"

--- a/src/workload.py
+++ b/src/workload.py
@@ -28,7 +28,7 @@ class ODWorkload(WorkloadBase):
 
     SNAP_NAME = "opensearch-dashboards"
     SNAP_APP_SERVICE = "opensearch-dashboards-daemon"
-    SNAP_EXPORTER_SERVICE = "kibana-exporter-daemon"
+    SNAP_EXPORTER_SERVICE = "exporter-daemon"
 
     def __init__(self):
         self.dashboards = snap.SnapCache()[self.SNAP_NAME]

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -169,7 +169,7 @@ def restart_unit(model_full_name: str, unit: str) -> None:
 
 
 def access_prometheus_exporter(host: str) -> bool:
-    """Check if a given unit has 'kibana-exporter' service available and publishing."""
+    """Check if a given unit has 'dashboard-exporter' service available and publishing."""
     try:
         # Normal IP address
         socket.inet_aton(host)
@@ -182,11 +182,11 @@ def access_prometheus_exporter(host: str) -> bool:
         response = requests.get(url)
     except requests.exceptions.RequestException:
         return False
-    return response.status_code == 200 and "kibana_status" in response.text
+    return response.status_code == 200 and "opensearch_dashboards_status" in response.text
 
 
 async def access_all_prometheus_exporters(ops_test: OpsTest) -> bool:
-    """Check if a given unit has 'kibana-exporter' service available and publishing."""
+    """Check if a given unit has 'dashboard-exporter' service available and publishing."""
     result = True
     for unit in ops_test.model.applications[APP_NAME].units:
         unit_ip = await get_address(ops_test, unit.name)

--- a/tests/unit/test_alert_rules/test_opensearch_dashboards_rules.yaml
+++ b/tests/unit/test_alert_rules/test_opensearch_dashboards_rules.yaml
@@ -6,7 +6,7 @@ evaluation_interval: 1m
 tests:
   - interval: 1m
     input_series:
-      - series: 'up{juju_unit="opensearch-dashboards/1"}'
+      - series: up{juju_unit="opensearch-dashboards/1"}
         values: '0x20'
     alert_rule_test:
       - eval_time: 5m
@@ -16,5 +16,107 @@ tests:
               severity: critical
               juju_unit: opensearch-dashboards/1
             exp_annotations:
-              message: "Scrape on opensearch-dashboards/1 failed. Ensure that the OpenSearch Dashboards systemd service is healthy."
-              summary: "OpenSearch exporter scrape failed"
+              description: Scrape on opensearch-dashboards/1 failed. Ensure that the OpenSearch Dashboards systemd service is healthy.
+              summary: OpenSearch exporter scrape failed
+
+  - interval: 1m
+    input_series:
+      - series: opensearch_dashboards_status{state="red",title="Red"}
+        values: '2x20'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: OpenSearchDashboardsRed
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              state: red
+              title: Red
+            exp_annotations:
+              description: "Dashboards status is red. The server may be down, it may have lost connection to Opensearch, or may suffer of partial unavailability."
+              summary: Server health status is red or plugins are down
+
+  - interval: 1m
+    input_series:
+      - series: opensearch_dashboards_status{state="yellow",title="Yellow"}
+        values: '1x50'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: OpenSearchDashboardsYellow
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              state: yellow
+              title: Yellow
+            exp_annotations:
+              description: Dashboards status is yellow. Plugins might be degraded or shards may be relocating or initializing.
+              summary: Dashboard health status is yellow
+
+  - interval: 1m
+    input_series:
+      # opensearch core is working fine
+      - series: opensearch_dashboards_statuses{state="green", id="core:opensearch@2.17.0", message="OpenSearch is available"}
+        values: '0x20'
+      # some plugin is missing a dependencies
+      - series: opensearch_dashboards_statuses{state="red", id="plugin:notificationsDashboards@2.17.0", message="Dependencies are broken"}
+        values: '2x20'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: OpenSearchDashboardsPluginRed
+        exp_alerts:
+          - exp_labels:
+              state: red
+              severity: critical
+              id: "plugin:notificationsDashboards@2.17.0"
+              message: Dependencies are broken
+            exp_annotations:
+              description: "Dashboards plugin:notificationsDashboards@2.17.0 status is red: Dependencies are broken"
+              summary: Dashboards plugin status is red
+
+  - interval: 1m
+    input_series:
+      # opensearch core is working fine
+      - series: opensearch_dashboards_statuses{state="green", id="core:opensearch@2.17.0", message="OpenSearch is available"}
+        values: '0x50'
+      # some plugin is missing a dependencies
+      - series: opensearch_dashboards_statuses{state="yellow", id="plugin:notificationsDashboards@2.17.0", message="Dependencies are not available"}
+        values: '1x50'
+    alert_rule_test:
+      - eval_time: 11m
+        alertname: OpenSearchDashboardsPluginYellow
+        exp_alerts:
+          - exp_labels:
+              state: yellow
+              severity: warning
+              id: "plugin:notificationsDashboards@2.17.0"
+              message: Dependencies are not available
+            exp_annotations:
+              description: "Dashboards plugin:notificationsDashboards@2.17.0 status is yellow: Dependencies are not available"
+              summary: Dashboards plugin status is yellow
+
+  - interval: 1m
+    input_series:
+      - series: opensearch_dashboards_up
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: OpenSearchDashboardsNoMetrics
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              description: Exporter failed to collect status metrics. Dashboards may be down or user and password may be invalid. Check the exporter logs.
+              summary: No metrics collected.
+
+  - interval: 1m
+    input_series:
+      - series: opensearch_dashboards_resp_time_avg
+        values: '300x20'
+    alert_rule_test:
+      - eval_time: 3m
+        alertname: OpenSearchDashboardsLongResponseTime
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+            exp_annotations:
+              description: The server is up and responsive, however with a high latency.
+              summary: High response time


### PR DESCRIPTION
Critical alerts for:
- dashboards in red state
- dashboards plugins in red state
- high response latency
- no metrics generation from the exporter

Warning alerts for:
- dashboards in yellow state
- dashboards plugins in yellow state

- Added unit tests for the new rules


I've manually tested and the metrics are working as expected and stopping the OpenSearch dashboars service triggers alert as expected:

![image](https://github.com/user-attachments/assets/7d898c8f-453f-4b6c-927c-30017d02e76d)


It was also necessary to change the dashboards to use the new metrics:
![image](https://github.com/user-attachments/assets/7b3b7ec9-f90c-41b8-a7e0-02133e17f9f3)

