### PR TITLE
[DPE-6600] Move away from libjuju's `add_machine`

### DIFF
--- a/tests/integration/spaces/test_wrong_etc_hosts.py
+++ b/tests/integration/spaces/test_wrong_etc_hosts.py
@@ -48,7 +48,7 @@ async def test_build_and_deploy(ops_test: OpsTest, lxd_spaces) -> None:
                 "add-machine",
                 f"--model={ops_test.model.name}",
                 '--constraints="spaces=alpha,cluster,backup,client"',
-                f"--series={SERIES}"
+                f"--series={SERIES}",
             ]
         )
 

--- a/tests/integration/spaces/test_wrong_etc_hosts.py
+++ b/tests/integration/spaces/test_wrong_etc_hosts.py
@@ -47,7 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest, lxd_spaces) -> None:
                 "juju",
                 "add-machine",
                 f"--model={ops_test.model.name}",
-                '--constraints="spaces=alpha,cluster,backup,client"',
+                '--constraints=spaces=alpha,cluster,backup,client',
                 f"--series={SERIES}",
             ]
         )

--- a/tests/integration/spaces/test_wrong_etc_hosts.py
+++ b/tests/integration/spaces/test_wrong_etc_hosts.py
@@ -47,7 +47,7 @@ async def test_build_and_deploy(ops_test: OpsTest, lxd_spaces) -> None:
                 "juju",
                 "add-machine",
                 f"--model={ops_test.model.name}",
-                '--constraints=spaces=alpha,cluster,backup,client',
+                "--constraints=spaces=alpha,cluster,backup,client",
                 f"--series={SERIES}",
             ]
         )

--- a/tests/integration/spaces/test_wrong_etc_hosts.py
+++ b/tests/integration/spaces/test_wrong_etc_hosts.py
@@ -42,10 +42,14 @@ async def test_build_and_deploy(ops_test: OpsTest, lxd_spaces) -> None:
     osd_charm = await ops_test.build_charm(".")
 
     for _ in range(DEFAULT_NUM_UNITS):
-        await ops_test.model.add_machine(
-            spec=None,
-            constraints={"spaces": ["alpha", "cluster", "backup", "client"]},
-            series=SERIES,
+        subprocess.check_output(
+            [
+                "juju",
+                "add-machine",
+                f"--model={ops_test.model.name}",
+                '--constraints="spaces=alpha,cluster,backup,client"',
+                f"--series={SERIES}"
+            ]
         )
 
     await for_machines(ops_test, machines=list(range(DEFAULT_NUM_UNITS)))


### PR DESCRIPTION
Libjuju is ignoring series on `add_machine`, as reported in: https://github.com/juju/python-libjuju/issues/1254

This PR fixes the CI run by moving from `add_machine` in libjuju to the actual juju CLI command.