### PR TITLE
[DPE-6687][DPE-6690][DPE-6691] Extend TF charm modules

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,7 +41,7 @@ resource "juju_application" "self-signed-certificates" {
   constraints = var.self-signed-certificates.constraints
   config      = var.self-signed-certificates.config
 
-  placement = len(var.self-signed-certificates.machines) == 1 ? var.self-signed-certificates.machines[0] : null
+  placement = length(var.self-signed-certificates.machines) == 1 ? var.self-signed-certificates.machines[0] : null
 }
 
 # Integrate with the self-signed-certificates if tls is enabled

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,7 +41,7 @@ resource "juju_application" "self-signed-certificates" {
   constraints = var.self-signed-certificates.constraints
   config      = var.self-signed-certificates.config
 
-  placement = var.self-signed-certificates.machines != null ? var.self-signed-certificates.machines[0] : null
+  placement = len(var.self-signed-certificates.machines) == 1 ? var.self-signed-certificates.machines[0] : null
 }
 
 # Integrate with the self-signed-certificates if tls is enabled

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ resource "juju_integration" "tls-opensearch_dashboards_integration" {
   model = var.model
 
   application {
-    name = juju_application.self-signed-certificates.name
+    name = juju_application.self-signed-certificates["deployed"].name
   }
 
   application {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,7 +15,6 @@ resource "juju_application" "opensearch-dashboards" {
   units       = var.units
   constraints = var.constraints
 
-
   # TODO: uncomment once final fixes have been added for:
   # Error: juju/terraform-provider-juju#443, juju/terraform-provider-juju#182
   # placement = join(",", var.machines)
@@ -25,13 +24,6 @@ resource "juju_application" "opensearch-dashboards" {
       endpoint = k, space = v
     }
   ]
-
-  lifecycle {
-    precondition {
-      condition     = length(var.machines) == 0 || length(var.machines) == var.units
-      error_message = "Machine count does not match unit count"
-    }
-  }
 }
 
 # Deploy the self-signed-certificates operator if tls enabled
@@ -46,8 +38,10 @@ resource "juju_application" "self-signed-certificates" {
     revision = var.self-signed-certificates.revision
     base     = var.self-signed-certificates.base
   }
+  constraints = var.self-signed-certificates.constraints
+  config      = var.self-signed-certificates.config
 
-  config = var.self-signed-certificates.config
+  placement = var.self-signed-certificates.machines != null ? var.self-signed-certificates.machines[0] : null
 }
 
 # Integrate with the self-signed-certificates if tls is enabled

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -41,9 +41,13 @@ resource "juju_application" "self-signed-certificates" {
   model = var.model
 
   charm {
-    name    = "self-signed-certificates"
-    channel = "latest/stable"
+    name     = "self-signed-certificates"
+    channel  = var.self-signed-certificates.channel
+    revision = var.self-signed-certificates.revision
+    base     = var.self-signed-certificates.base
   }
+
+  config = var.self-signed-certificates.config
 }
 
 # Integrate with the self-signed-certificates if tls is enabled
@@ -53,7 +57,7 @@ resource "juju_integration" "tls-opensearch_dashboards_integration" {
   model = var.model
 
   application {
-    name = "self-signed-certificates"
+    name = juju_application.self-signed-certificates.name
   }
 
   application {

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -20,7 +20,7 @@ output "provides" {
 output app_names {
   description = "Output of all deployed application names."
   value = {
-    opensearch-dashboards     = juju_application.opensearch-dashboards.name
-    self-signed-certificates  = var.tls ? juju_application.self-signed-certificates["deployed"].name : null
+    opensearch-dashboards    = juju_application.opensearch-dashboards.name
+    self-signed-certificates = var.tls ? juju_application.self-signed-certificates["deployed"].name : null
   }
 }

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -17,7 +17,7 @@ output "provides" {
   }
 }
 
-output app_names {
+output "app_names" {
   description = "Output of all deployed application names."
   value = {
     opensearch-dashboards    = juju_application.opensearch-dashboards.name

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,11 +1,6 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-output "app_name" {
-  description = "Name of the deployed application."
-  value       = juju_application.opensearch-dashboards.name
-}
-
 # integration endpoints
 output "requires" {
   description = "Map of all \"requires\" endpoints"
@@ -19,5 +14,13 @@ output "provides" {
   description = "Map of all \"provides\" endpoints"
   value = {
     cos_agent = "cos-agent"
+  }
+}
+
+output app_names {
+  description = "Output of all deployed application names."
+  value = {
+    opensearch-dashboards     = juju_application.opensearch-dashboards.name
+    self-signed-certificates  = var.tls ? juju_application.self-signed-certificates["deployed"].name : null
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,3 +66,19 @@ variable "tls" {
   type        = bool
   default     = false
 }
+
+variable "self-signed-certificates" {
+  description = "Configuration for the self-signed-certificates app"
+  type = object({
+    channel       = optional(string, "latest/stable")
+    revision      = optional(string, null)
+    base          = optional(string, "ubuntu@22.04")
+    config        = optional(map(string), { "ca-common-name": "CA" })
+  })
+  default = {
+    channel  = "latest/stable"
+    revision = null
+    base     = "ubuntu@22.04"
+    config   = { "ca-common-name" = "CA" }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -52,6 +52,11 @@ variable "machines" {
   description = "List of machines for placement"
   type        = list(string)
   default     = []
+
+  validation {
+    condition     = length(var.machines) == 0 || length(var.machines) == var.units
+    error_message = "Machine count does not match unit count"
+  }
 }
 
 variable "endpoint_bindings" {
@@ -70,15 +75,17 @@ variable "tls" {
 variable "self-signed-certificates" {
   description = "Configuration for the self-signed-certificates app"
   type = object({
-    channel       = optional(string, "latest/stable")
-    revision      = optional(string, null)
-    base          = optional(string, "ubuntu@22.04")
-    config        = optional(map(string), { "ca-common-name": "CA" })
+    channel     = optional(string, "latest/stable")
+    revision    = optional(string, null)
+    base        = optional(string, "ubuntu@22.04")
+    constraints = optional(string, "arch=amd64")
+    machines    = optional(list(string), [])
+    config      = optional(map(string), { "ca-common-name" : "CA" })
   })
-  default = {
-    channel  = "latest/stable"
-    revision = null
-    base     = "ubuntu@22.04"
-    config   = { "ca-common-name" = "CA" }
+  default = {}
+
+  validation {
+    condition     = length(var.self-signed-certificates.machines) <= 1
+    error_message = "Machine count should be at most 1"
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.14.0"
+      version = ">= 0.14.0"
     }
   }
 }


### PR DESCRIPTION
## Issue
This PR addresses: [DPE-6687](https://warthogs.atlassian.net/browse/DPE-6687), [DPE-6690](https://warthogs.atlassian.net/browse/DPE-6690), [DPE-6691](https://warthogs.atlassian.net/browse/DPE-6691). 
Namely, this PR addresses:
- fix versioning constraints of the juju TF provider
- expose config + constraints + base + channel etc in internally used charms for flexible use
- add output variables in product modules

[DPE-6687]: https://warthogs.atlassian.net/browse/DPE-6687?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-6690]: https://warthogs.atlassian.net/browse/DPE-6690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DPE-6691]: https://warthogs.atlassian.net/browse/DPE-6691?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ