### PR TITLE
[DPE-6858][TF] Add expose support

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -22,6 +22,7 @@ The module offers the following configurable inputs:
 | `units`       | number      | Number of units to be deployed                  | False      |
 | `constraints` | string      | Machine constraints for the charm               | False      |
 | `tls`         | bool        | Whether TLS should be enabled                   | False      |
+| `expose`      | bool        | If set to true, opens to anyone's access        | False      |
 
 
 ### Outputs

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -15,6 +15,11 @@ resource "juju_application" "opensearch-dashboards" {
   units       = var.units
   constraints = var.constraints
 
+  dynamic "expose" {
+    for_each = var.expose ? [1] : []
+    content {}
+  }
+
   # TODO: uncomment once final fixes have been added for:
   # Error: juju/terraform-provider-juju#443, juju/terraform-provider-juju#182
   # placement = join(",", var.machines)

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -65,6 +65,12 @@ variable "endpoint_bindings" {
   default     = {}
 }
 
+variable "expose" {
+  description = "Expose the application"
+  type        = bool
+  default     = false
+}
+
 # additional variables
 variable "tls" {
   description = "Whether TLS should be enabled"


### PR DESCRIPTION
This PR adds `expose` as a variable and subsequent dynamic block. If the expose is set to true, then the dynamic block renders `expose {}`, which effectively exposes the application to any external access.

Terraform plan with `expose=true`: https://pastebin.ubuntu.com/p/M7RvwmSK22/
Terraform plan without expose (hence defaulting to `false`): https://pastebin.ubuntu.com/p/NTPGzcMPP7/