### PR TITLE
[DPE-6936] - Update to 2.19.1

### DIFF
--- a/src/literals.py
+++ b/src/literals.py
@@ -4,7 +4,7 @@
 
 """Collection of global literals for the charm."""
 
-OPENSEARCH_DASHBOARDS_SNAP_REVISION = "28"
+OPENSEARCH_DASHBOARDS_SNAP_REVISION = "30"
 
 SUBSTRATE = "vm"
 CHARM_KEY = "opensearch-dashboards"
@@ -20,10 +20,10 @@ SERVER_PORT = 5601
 
 DEPENDENCIES = {
     "osd_upstream": {
-        "dependencies": {"opensearch": "2.18"},
+        "dependencies": {"opensearch": "2.19.1"},
         "name": "opensearch-dashboards",
         "upgrade_supported": ">=2",
-        "version": "2.18",
+        "version": "2.19.1",
     },
 }
 


### PR DESCRIPTION
This pull request updates version-related literals in the `src/literals.py` file to align with the latest releases. The changes ensure compatibility with the updated versions of OpenSearch and OpenSearch Dashboards.

Version updates:

* Updated the `OPENSEARCH_DASHBOARDS_SNAP_REVISION` constant from `"28"` to `"30"`.
* Updated the OpenSearch dependency version from `"2.18"` to `"2.19.1"` in the `DEPENDENCIES` dictionary, including both the `dependencies` and `version` fields.