### PR TITLE
fix: start ssh service instead of reload

### DIFF
--- a/spread.yaml
+++ b/spread.yaml
@@ -80,7 +80,7 @@ backends:
       EOF
 
       sudo systemctl daemon-reload
-      sudo systemctl reload ssh
+      sudo systemctl start ssh
 
       # Needed for IS-hosted runners
       sudo passwd --delete ubuntu


### PR DESCRIPTION
This pull request includes a small change to the `spread.yaml` file. The change updates the SSH service management command from `reload` to `start` in the `backends` section.