### PR TITLE
Avoid to return a version mismatch if the version is not set in the relation yet

### DIFF
--- a/src/managers/upgrade.py
+++ b/src/managers/upgrade.py
@@ -31,7 +31,7 @@ class UpgradeManager:
     def version_compatible(self) -> bool:
         """Verify version compatibility with Opensearch."""
         # When there's no Opensearch connection, we shouldn't report version mismatch
-        if not self.state.opensearch_server:
+        if not self.state.opensearch_server or not self.state.opensearch_server.version:
             return True
 
         if not (srv_version_actual := self.state.opensearch_server.version):


### PR DESCRIPTION
If I understood correctly, when the relation is initialized by the dashboard, it does not contain a "version" key, it's set later by the indexer.
If the version_compatible function is called before the version is set, the charm may turn in a blocked state, blocking other operations and resulting in the charm being stuck forever.