### PR TITLE
Omit tag job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,7 +21,7 @@ jobs:
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:
-      track: ${{ needs.tag.outputs.track }}
+      track: "2"
       artifact-prefix: ${{ needs.ci-tests.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,14 +8,6 @@ on:
       - 2/edge
 
 jobs:
-  tag:
-    name: Create charm refresh compatibility version git tag
-    uses: canonical/data-platform-workflows/.github/workflows/tag_charm_edge.yaml@v32.1.0
-    with:
-      track: '2'
-    permissions:
-      contents: write  # Needed to create git tag
-
   ci-tests:
     name: Tests
     uses: ./.github/workflows/ci.yaml
@@ -26,7 +18,6 @@ jobs:
   release:
     name: Release charm
     needs:
-      - tag
       - ci-tests
     uses: canonical/data-platform-workflows/.github/workflows/release_charm_edge.yaml@v32.1.0
     with:


### PR DESCRIPTION
This PR removes the `tag` job. The `release_charm_edge` [release notes](https://github.com/canonical/data-platform-workflows/blob/main/.github/workflows/release_charm_edge.md) indicate it should be omitted if we don't implement refresh v3.