### PR TITLE
[DPE-7927] - Disable TLS on relation broken

### DIFF
--- a/src/events/tls.py
+++ b/src/events/tls.py
@@ -144,8 +144,7 @@ class TLSEvents(Object):
     def _on_certs_relation_broken(self, _) -> None:
         """Handler for `certificates_relation_broken` event."""
         # In case we have valid certificates, we keep them for smooth service function
-        if self.charm.state.unit_server.tls and not self.charm.tls_manager.certificate_valid():
-            self._remove_certificates()
+        self._remove_certificates()
 
     def _set_tls_private_key(self, event: ActionEvent) -> None:
         """Handler for `set-tls-privat-key` event when user manually specifies private-keys for a unit."""

--- a/tests/integration/test_charm.py
+++ b/tests/integration/test_charm.py
@@ -8,7 +8,6 @@ import re
 from pathlib import Path
 
 import pytest
-import requests
 import yaml
 from pytest_operator.plugin import OpsTest
 
@@ -139,18 +138,14 @@ async def test_dashboard_access_https(ops_test: OpsTest):
         apps=[APP_NAME, TLS_CERTIFICATES_APP_NAME], status="active", timeout=1000
     )
 
-    # Event thought the TLS connection is not there, we do NOT switch back to HTTP
-    with pytest.raises(requests.exceptions.ConnectionError):
-        await access_all_dashboards(ops_test, opensearch_relation.id)
-
-    # Instead, HTTPS works uninterrupted
-    assert await access_all_dashboards(ops_test, opensearch_relation.id, https=True)
-
     server_cert = (
         "/var/snap/opensearch-dashboards/current/etc/opensearch-dashboards/certificates/server.pem"
     )
     unit = ops_test.model.applications[APP_NAME].units[0]
     host_cert = get_file_contents(ops_test, unit, server_cert)
+
+    # TLS Broken on relation removal we check the connection on HTTP
+    await access_all_dashboards(ops_test, opensearch_relation.id)
 
     # Restore relation for further tests
     await ops_test.model.integrate(APP_NAME, TLS_CERTIFICATES_APP_NAME)

--- a/tests/unit/test_tls.py
+++ b/tests/unit/test_tls.py
@@ -11,7 +11,6 @@ from ops.testing import Harness
 
 from charm import OpensearchDashboardsCharm
 from literals import CERTS_REL_NAME, CHARM_KEY, PEER
-from src.events.tls import TLSEvents
 
 CONFIG = str(yaml.safe_load(Path("./config.yaml").read_text()))
 ACTIONS = str(yaml.safe_load(Path("./actions.yaml").read_text()))
@@ -130,13 +129,12 @@ def test_certificates_broken(harness):
 
         harness.remove_relation(certs_rel_id)
 
-        # While the TLS relation is gone
+        # While the TLS relation and certs are gone
         assert not harness.charm.state.cluster.tls
-        # ...we've still preserved certs locally
-        assert harness.charm.state.unit_server.certificate
-        assert harness.charm.state.unit_server.ca
-        assert harness.charm.state.unit_server.csr
-        assert harness.charm.state.unit_server.tls
+        assert not harness.charm.state.unit_server.certificate
+        assert not harness.charm.state.unit_server.ca
+        assert not harness.charm.state.unit_server.csr
+        assert not harness.charm.state.unit_server.tls
 
         assert workload_config.assert_called_once
 


### PR DESCRIPTION
This pull request updates the TLS certificate handling logic to remove the certificates and disable TLS when the TLS relation is broken. It also adjusts the corresponding unit tests to reflect the new behavior.

TLS certificate removal:

* Modified the `_on_certs_relation_broken` method in `src/events/tls.py` to always remove certificates when the relation is broken, regardless of certificate validity.

Unit test updates:

* Updated `test_certificates_broken` in `tests/unit/test_tls.py` to assert that all certificate-related fields (`certificate`, `ca`, `csr`, `tls`) are cleared when the TLS relation is removed.
* Removed an unused import of `TLSEvents` from `tests/unit/test_tls.py`.