### PR TITLE
[DPE-7774]: Raise if error on install

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -19,6 +19,7 @@ from events.oauth import OAuthHandler
 from events.requirer import RequirerEvents
 from events.tls import TLSEvents
 from events.upgrade import ODUpgradeEvents, OpensearchDashboardsDependencyModel
+from exceptions import OSDInstallError
 from helpers import (
     clear_global_status,
     clear_status,
@@ -134,6 +135,9 @@ class OpensearchDashboardsCharm(CharmBase):
         install = self.workload.install()
         if not install:
             self.unit.status = BlockedStatus("unable to install Opensearch Dashboards")
+            raise OSDInstallError(
+                "failed to install the Opensearch Dashboards snap. check logs for more details"
+            )
 
         # don't complete install until passwords set
         if not self.state.peer_relation:

--- a/src/charm.py
+++ b/src/charm.py
@@ -19,7 +19,6 @@ from events.oauth import OAuthHandler
 from events.requirer import RequirerEvents
 from events.tls import TLSEvents
 from events.upgrade import ODUpgradeEvents, OpensearchDashboardsDependencyModel
-from exceptions import OSDInstallError
 from helpers import (
     clear_global_status,
     clear_status,
@@ -132,11 +131,7 @@ class OpensearchDashboardsCharm(CharmBase):
         """Handler for the `on_install` event."""
         self.unit.status = MaintenanceStatus(MSG_INSTALLING)
 
-        if not self.workload.install():
-            self.unit.status = BlockedStatus("unable to install Opensearch Dashboards")
-            raise OSDInstallError(
-                "failed to install the Opensearch Dashboards snap. check logs for more details"
-            )
+        self.workload.install()
 
         # don't complete install until passwords set
         if not self.state.peer_relation:

--- a/src/charm.py
+++ b/src/charm.py
@@ -132,8 +132,7 @@ class OpensearchDashboardsCharm(CharmBase):
         """Handler for the `on_install` event."""
         self.unit.status = MaintenanceStatus(MSG_INSTALLING)
 
-        install = self.workload.install()
-        if not install:
+        if not self.workload.install():
             self.unit.status = BlockedStatus("unable to install Opensearch Dashboards")
             raise OSDInstallError(
                 "failed to install the Opensearch Dashboards snap. check logs for more details"

--- a/src/events/upgrade.py
+++ b/src/events/upgrade.py
@@ -18,6 +18,7 @@ from charms.data_platform_libs.v0.upgrade import (
 from ops.model import BlockedStatus
 from typing_extensions import override
 
+from exceptions import OSDInstallError
 from literals import MSG_INCOMPATIBLE_UPGRADE
 
 if TYPE_CHECKING:
@@ -88,7 +89,9 @@ class ODUpgradeEvents(DataUpgrade):
     def _on_upgrade_granted(self, event: UpgradeGrantedEvent) -> None:
         self.charm.workload.stop()
 
-        if not self.charm.workload.install():
+        try:
+            self.charm.workload.install()
+        except OSDInstallError:
             logger.error("Unable to install OpensearchDashboards...")
             self.set_unit_failed(cause="Workload install failed")
             return

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -11,3 +11,7 @@ class OSDError(Exception):
 
 class OSDAPIError(OSDError):
     """Exception relating to OSD API access."""
+
+
+class OSDInstallError(OSDError):
+    """Exception relating to OSD installation issues."""

--- a/src/workload.py
+++ b/src/workload.py
@@ -11,7 +11,7 @@ import string
 import subprocess
 
 from charms.operator_libs_linux.v2 import snap
-from tenacity import retry
+from tenacity import retry, retry_if_result
 from tenacity.retry import retry_any, retry_if_exception, retry_if_not_result
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
@@ -119,7 +119,12 @@ class ODWorkload(WorkloadBase):
         return self.alive()
 
     # --- Charm Specific ---
-
+    @retry(
+        stop=stop_after_attempt(3),
+        wait=wait_fixed(5),
+        reraise=True,
+        retry=retry_if_result(lambda result: result is False),
+    )
     def install(self) -> bool:
         """Loads the snap from LP, returning a StatusBase for the Charm to set.
 

--- a/src/workload.py
+++ b/src/workload.py
@@ -11,13 +11,14 @@ import string
 import subprocess
 
 from charms.operator_libs_linux.v2 import snap
-from tenacity import retry, retry_if_result
+from tenacity import retry, retry_if_exception_type
 from tenacity.retry import retry_any, retry_if_exception, retry_if_not_result
 from tenacity.stop import stop_after_attempt
 from tenacity.wait import wait_fixed
 from typing_extensions import override
 
 from core.workload import WorkloadBase
+from exceptions import OSDInstallError
 from literals import OPENSEARCH_DASHBOARDS_SNAP_REVISION
 
 logger = logging.getLogger(__name__)
@@ -123,14 +124,10 @@ class ODWorkload(WorkloadBase):
         stop=stop_after_attempt(3),
         wait=wait_fixed(5),
         reraise=True,
-        retry=retry_if_result(lambda result: result is False),
+        retry=retry_if_exception_type(OSDInstallError),
     )
-    def install(self) -> bool:
-        """Loads the snap from LP, returning a StatusBase for the Charm to set.
-
-        Returns:
-            True if successfully installed. False otherwise.
-        """
+    def install(self) -> None:
+        """Loads the snap from LP, returning a StatusBase for the Charm to set."""
         try:
             cache = snap.SnapCache()
             dashboards = cache[self.SNAP_NAME]
@@ -139,11 +136,11 @@ class ODWorkload(WorkloadBase):
 
             self.dashboards = dashboards
             self.dashboards.hold()
-
-            return True
         except snap.SnapError as e:
             logger.error(str(e))
-            return False
+            raise OSDInstallError(
+                "failed to install the Opensearch Dashboards snap. check logs for more details"
+            )
 
     def generate_password(self) -> str:
         """Creates randomized string for use as app passwords.

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -16,12 +16,17 @@ from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingSta
 from ops.testing import Harness
 
 from charm import OpensearchDashboardsCharm, OpensearchDashboardsDependencyModel
+from exceptions import OSDInstallError
 from helpers import clear_status, update_grafana_dashboards_title
-from literals import CHARM_KEY, CONTAINER, OPENSEARCH_REL_NAME, PEER, SUBSTRATE
-from src.literals import (
+from literals import (
+    CHARM_KEY,
+    CONTAINER,
     MSG_INCOMPATIBLE_UPGRADE,
     MSG_STATUS_ERROR,
     MSG_STATUS_UNHEALTHY,
+    OPENSEARCH_REL_NAME,
+    PEER,
+    SUBSTRATE,
 )
 
 logger = logging.getLogger(__name__)
@@ -123,7 +128,10 @@ def test_install_blocks_snap_install_failure(harness):
         harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         harness.set_leader(True)
 
-    with patch("workload.ODWorkload.install", return_value=False):
+    with (
+        patch("workload.ODWorkload.install", return_value=False),
+        pytest.raises(OSDInstallError),
+    ):
         harness.charm.on.install.emit()
 
         assert isinstance(harness.model.unit.status, BlockedStatus)
@@ -135,7 +143,7 @@ def test_install_sets_ip_hostname_fqdn(harness):
         harness.add_relation_unit(peer_rel_id, f"{CHARM_KEY}/0")
         harness.set_leader(True)
 
-    with patch("workload.ODWorkload.install", return_value=False):
+    with patch("workload.ODWorkload.install", return_value=True):
         harness.charm.on.install.emit()
 
         assert harness.charm.state.bind_address

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -129,12 +129,10 @@ def test_install_blocks_snap_install_failure(harness):
         harness.set_leader(True)
 
     with (
-        patch("workload.ODWorkload.install", return_value=False),
+        patch("workload.ODWorkload.install", side_effect=OSDInstallError("install failed")),
         pytest.raises(OSDInstallError),
     ):
         harness.charm.on.install.emit()
-
-        assert isinstance(harness.model.unit.status, BlockedStatus)
 
 
 def test_install_sets_ip_hostname_fqdn(harness):

--- a/tests/unit/test_upgrade.py
+++ b/tests/unit/test_upgrade.py
@@ -14,6 +14,7 @@ from ops.testing import Harness
 
 from charm import OpensearchDashboardsCharm
 from events.upgrade import ODUpgradeEvents, OpensearchDashboardsDependencyModel
+from exceptions import OSDInstallError
 from literals import CHARM_KEY, DEPENDENCIES
 from src.literals import MSG_INCOMPATIBLE_UPGRADE
 from tests.unit.test_charm import OPENSEARCH_REL_NAME
@@ -134,7 +135,7 @@ def test_dashboards_dependency_model():
 def test_upgrade_granted_sets_failed_if_failed_snap(harness, mocker):
     mocker.patch.object(ODWorkload, "stop")
     mocker.patch.object(ODWorkload, "restart")
-    mocker.patch.object(ODWorkload, "install", return_value=False)
+    mocker.patch.object(ODWorkload, "install", side_effect=OSDInstallError("install failed"))
     mocker.patch.object(ODUpgradeEvents, "pre_upgrade_check")
     mocker.patch.object(ODUpgradeEvents, "set_unit_completed")
     mocker.patch.object(ODUpgradeEvents, "set_unit_failed")


### PR DESCRIPTION
This pull request improves error handling during the installation process of Opensearch Dashboards by introducing a custom exception for installation failures and updating related unit tests to ensure correct behavior. 

fixes #202 

**Error Handling Improvements:**
* Added a new `OSDInstallError` exception in `src/exceptions.py` to specifically handle Opensearch Dashboards installation issues.
* Updated `src/charm.py` to raise `OSDInstallError` when the workload installation fails. [[1]](diffhunk://#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cR22) [[2]](diffhunk://#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cR138-R140)

**Testing Updates:**
* Updated the `test_install_blocks_snap_install_failure` test to expect the new exception when installation fails, ensuring the charm properly blocks and reports errors.
* Corrected the `test_install_sets_ip_hostname_fqdn` test to patch the install method with a successful return value, aligning with the intended test scenario.