### PR TITLE
[DPE7928]: block if we fail to get the provider info from the oauth relation

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -38,9 +38,11 @@ from literals import (
     MSG_STARTING_SERVER,
     MSG_STATUS_DB_MISSING,
     MSG_STATUS_HANGING,
+    MSG_STATUS_OAUTH_INFO_FAILED,
     MSG_TLS_CONFIG,
     MSG_UNIT_STATUS,
     MSG_WAITING_FOR_PEER,
+    OAUTH_REL_NAME,
     PEER,
     RESTART_TIMEOUT,
     SERVER_PORT,
@@ -227,6 +229,11 @@ class OpensearchDashboardsCharm(CharmBase):
             return
         else:
             outdated_status += MSG_UNIT_STATUS
+
+        # check oauth status and make sure we have received the oauth_client_secret
+        if self.model.get_relation(OAUTH_REL_NAME) and not self.state.cluster.oauth_client_secret:
+            set_global_status(self, BlockedStatus(MSG_STATUS_OAUTH_INFO_FAILED))
+            return
 
         # Clear all possible irrelevant statuses
         for status in outdated_status:

--- a/src/events/oauth.py
+++ b/src/events/oauth.py
@@ -42,7 +42,7 @@ class OAuthHandler(Object):
         try:
             provider_info = self.oauth.get_provider_info()
         except ModelError as e:
-            logger.warning("OAuth provider info not available: %s", e)
+            logger.error("OAuth provider info not available: %s", e)
             set_global_status(self.charm, BlockedStatus(MSG_STATUS_OAUTH_INFO_FAILED))
             event.defer()
             return

--- a/src/events/oauth.py
+++ b/src/events/oauth.py
@@ -8,9 +8,10 @@ import logging
 from typing import TYPE_CHECKING
 
 from charms.hydra.v0.oauth import ClientConfig, OAuthRequirer
-from ops import EventBase, Object
+from ops import BlockedStatus, EventBase, ModelError, Object
 
-from literals import OAUTH_REL_NAME
+from helpers import set_global_status
+from literals import MSG_STATUS_OAUTH_INFO_FAILED, OAUTH_REL_NAME
 
 if TYPE_CHECKING:
     from charm import OpensearchDashboardsCharm
@@ -38,9 +39,13 @@ class OAuthHandler(Object):
         if not self.charm.state.servers:
             event.defer()
             return
-
-        provider_info = self.oauth.get_provider_info()
-
+        try:
+            provider_info = self.oauth.get_provider_info()
+        except ModelError as e:
+            logger.warning("OAuth provider info not available: %s", e)
+            set_global_status(self.charm, BlockedStatus(MSG_STATUS_OAUTH_INFO_FAILED))
+            event.defer()
+            return
         self.charm.state.cluster.update(
             {
                 "oauth-client-secret": (

--- a/src/literals.py
+++ b/src/literals.py
@@ -63,6 +63,7 @@ MSG_STATUS_WORKLOAD_DOWN = "Workload is not alive"
 MSG_STATUS_UNKNOWN = "Workload status is not known"
 MSG_STATUS_APP_REMOVED = "remove-application was requested: leaving..."
 MSG_STATUS_HANGING = "Application does not respond, request hanging"
+MSG_STATUS_OAUTH_INFO_FAILED = "Failed to get OAuth provider info from relation"
 
 MSG_APP_STATUS = [
     MSG_STATUS_DB_DOWN,

--- a/src/managers/health.py
+++ b/src/managers/health.py
@@ -8,9 +8,9 @@ import logging
 import os
 
 import requests
-from requests.exceptions import ConnectionError, HTTPError
-from tenacity import Retrying, stop_after_attempt, wait_fixed, RetryCallState
 import urllib3
+from requests.exceptions import ConnectionError, HTTPError
+from tenacity import RetryCallState, Retrying, stop_after_attempt, wait_fixed
 
 from core.cluster import SUBSTRATES, ClusterState
 from core.workload import WorkloadBase

--- a/tests/integration/test_jwt_auth.py
+++ b/tests/integration/test_jwt_auth.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 import requests
 import yaml
-
 from pytest_operator.plugin import OpsTest
 
 from .helpers import (

--- a/tests/unit/test_health.py
+++ b/tests/unit/test_health.py
@@ -20,7 +20,7 @@ from literals import (
     OPENSEARCH_REL_NAME,
     SUBSTRATE,
 )
-from src.literals import MSG_STATUS_DB_DOWN, MSG_STATUS_HANGING, MSG_STATUS_DB_UNHEALTHY
+from src.literals import MSG_STATUS_DB_DOWN, MSG_STATUS_DB_UNHEALTHY, MSG_STATUS_HANGING
 from tests.unit.test_charm import MSG_STATUS_UNHEALTHY
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
This pull request improves the handling of OAuth relation errors. The main changes ensure that the application sets a clear blocked status if OAuth provider information cannot be retrieved.

**OAuth error handling and status messaging:**

* Added a new status message `MSG_STATUS_OAUTH_INFO_FAILED` to indicate when OAuth provider info retrieval fails, and integrated it into the charm's status management logic (`src/literals.py`, `src/charm.py`). [[1]](diffhunk://#diff-959ba637043ab4ac88c6f9f9109022f78a7df1b9a2ab3a0407bff4f124c2db64R66) [[2]](diffhunk://#diff-b9ed39bbc9c0387bd3e07da31d13373745534a1cd723d3e292c73496b12e307cR41-R45)
* Updated the OAuth relation event handler to catch `ModelError` exceptions, set the blocked status using the new message, and defer the event for retry (`src/events/oauth.py`).
* In the charm's `reconcile` method, added a check to block the unit if the OAuth relation exists but the client secret is missing, using the new status message (`src/charm.py`).

**Code format from previous PRs**

* Import orders in `src/managers/health.py`, `src/events/oauth.py`, and test files (`src/managers/health.py`, `tests/unit/test_health.py`). [[1]](diffhunk://#diff-1c1eb9ed1fce2cd4c152d62050084b4c45b818871731b15eea2a75cc333db063L11-R13) [[2]](diffhunk://#diff-7d85799a61cbcd59e21b46fc429f0364ce2437c3a88cd373ad026789f4e8d582L11-R14) [[3]](diffhunk://#diff-ab59585125fbc3d673fc548b2dc936c14ea6f7dc099d86b149cdd70d6aa24351L23-R23) [[4]](diffhunk://#diff-96a7b6985eb898774a79efa81c07dcb639fcbf65223844890cc02350fb3e7f7eL11)