### PR TITLE
Unblock CI pipeline

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -88,7 +88,7 @@ jobs:
     timeout-minutes: 217 # Sum of steps `timeout-minutes` + 5
     steps:
       - name: Disk usage
-        timeout-minutes: 1
+        timeout-minutes: 5
         run: df --human-readable
       - name: Checkout
         timeout-minutes: 3
@@ -107,6 +107,11 @@ jobs:
         with:
           pattern: ${{ inputs.artifact-prefix }}-*
           merge-multiple: true
+      # TODO Remove pinned image when https://bugs.launchpad.net/snapd/+bug/2127244 is resolved
+      - name: Pin lxc image for jammy
+        run: |
+          sudo lxc image copy ubuntu:568f69ff1166 local:
+          sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
       - name: Run spread job
         timeout-minutes: 180
         id: spread


### PR DESCRIPTION
This PR should unblock the CI pipeline, which is currently failing for almost all integration tests because of https://bugs.launchpad.net/snapd/+bug/2127244.

Changes:
- pin lxd image for 22.04 (as a workaround)
- increase timeout for `Disk usage` to 5 min (known issue)