### PR TITLE
Bump terraform provider to v1.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,8 +110,9 @@ jobs:
           juju add-model test
       - name: Terraform deploy
         run: |
+          MODEL_UUID=$(juju show-model test | grep "model-uuid" | awk '{split($0, a, ": "); print a[2]}')
           pushd ./terraform
-          terraform apply -var='model=test' -auto-approve
+          terraform apply -var='model_uuid=$MODLE_UUID' -auto-approve
           popd
       - name: Wait for model and applications
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         run: |
           MODEL_UUID=$(juju show-model test | grep "model-uuid" | awk '{split($0, a, ": "); print a[2]}')
           pushd ./terraform
-          terraform apply -var="model_uuid=$MODLE_UUID" -auto-approve
+          terraform apply -var="model_uuid=$MODEL_UUID" -auto-approve
           popd
       - name: Wait for model and applications
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         run: |
           MODEL_UUID=$(juju show-model test | grep "model-uuid" | awk '{split($0, a, ": "); print a[2]}')
           pushd ./terraform
-          terraform apply -var='model_uuid=$MODLE_UUID' -auto-approve
+          terraform apply -var="model_uuid=$MODLE_UUID" -auto-approve
           popd
       - name: Wait for model and applications
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -118,8 +118,6 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Set up environment
         run: |
-          sudo snap install charmcraft --classic
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -30,8 +31,12 @@ jobs:
           import subprocess
 
           spread_jobs = (
+
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci"], capture_output=True, check=True, text=True
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
               )
               .stdout.strip()
               .split("\n")

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -118,6 +118,10 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
+        with:
+          detached: true
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -29,6 +29,7 @@ jobs:
           import json
           import os
           import subprocess
+          import pathlib
 
           spread_jobs = (
 

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -118,6 +118,8 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -129,11 +129,14 @@ jobs:
 
           if [ -n "$DOCKERHUB_MIRROR" ]; then
           echo "Configuring dockerhub mirror"
-          MIRROR_CONFIG=/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
+          REGISTRY_DIR="/var/snap/microk8s/current/args/certs.d/docker.io"
+          MIRROR_CONFIG="$REGISTRY_DIR/hosts.toml"
 
-          sudo mkdir -p ${MIRROR_CONFIG}
+          sudo mkdir -p "$REGISTRY_DIR"
+
           sudo chown "$USER" ${MIRROR_CONFIG}
           cat << EOF > ${MIRROR_CONFIG}/hosts.toml
+          server = "$DOCKERHUB_MIRROR"
           [host."$DOCKERHUB_MIRROR"]
           capabilities = ["pull", "resolve"]
           EOF

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -122,6 +122,22 @@ jobs:
         uses: canonical/action-tmate@main
         with:
           detached: true
+      - name: Install microk8s
+        run: |
+          sudo snap install microk8s --classic 
+          sudo snap install kubectl  --classic
+          if [ -n "$DOCKERHUB_MIRROR" ]; then
+            echo "Configuring dockerhub mirror"
+            MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
+
+            sudo mkdir -p ${MIRROR_CONFIG}
+            sudo chown $USER ${MIRROR_CONFIG}
+            cat << EOF > ${MIRROR_CONFIG}/hosts.toml
+            [host."$DOCKERHUB_MIRROR"]
+            capabilities = ["pull", "resolve"]
+            EOF
+          fi
+
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -126,16 +126,17 @@ jobs:
         run: |
           sudo snap install microk8s --classic 
           sudo snap install kubectl  --classic
-          if [ -n "$DOCKERHUB_MIRROR" ]; then
-            echo "Configuring dockerhub mirror"
-            MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
 
-            sudo mkdir -p ${MIRROR_CONFIG}
-            sudo chown $USER ${MIRROR_CONFIG}
-            cat << EOF > ${MIRROR_CONFIG}/hosts.toml
-            [host."$DOCKERHUB_MIRROR"]
-            capabilities = ["pull", "resolve"]
-            EOF
+          if [ -n "$DOCKERHUB_MIRROR" ]; then
+          echo "Configuring dockerhub mirror"
+          MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
+
+          sudo mkdir -p ${MIRROR_CONFIG}
+          sudo chown "$USER" ${MIRROR_CONFIG}
+          cat << EOF > ${MIRROR_CONFIG}/hosts.toml
+          [host."$DOCKERHUB_MIRROR"]
+          capabilities = ["pull", "resolve"]
+          EOF
           fi
 
       - name: Run spread job

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -129,7 +129,7 @@ jobs:
 
           if [ -n "$DOCKERHUB_MIRROR" ]; then
           echo "Configuring dockerhub mirror"
-          MIRROR_CONFIG=/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io
+          MIRROR_CONFIG=/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml
 
           sudo mkdir -p ${MIRROR_CONFIG}
           sudo chown "$USER" ${MIRROR_CONFIG}

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -138,6 +138,8 @@ jobs:
           capabilities = ["pull", "resolve"]
           EOF
           fi
+          sudo microk8s stop
+          sudo microk8s start
 
       - name: Run spread job
         timeout-minutes: 180

--- a/spread.yaml
+++ b/spread.yaml
@@ -98,6 +98,7 @@ backends:
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
       GCP_SERVICE_ACCOUNT: '$(HOST: echo $GCP_SERVICE_ACCOUNT)'
+      DOCKERHUB_MIRROR: '$(HOST: echo $DOCKERHUB_MIRROR)'
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
     systems:

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ resource "juju_application" "opensearch-dashboards" {
     base     = var.base
   }
   config      = var.config
-  model       = var.model
+  model_uuid  = var.model_uuid
   name        = var.app_name
   units       = var.units
   constraints = var.constraints
@@ -35,7 +35,7 @@ resource "juju_application" "opensearch-dashboards" {
 resource "juju_application" "self-signed-certificates" {
   for_each = var.tls ? { "deployed" = true } : {}
 
-  model = var.model
+  model_uuid = var.model_uuid
 
   charm {
     name     = "self-signed-certificates"
@@ -46,14 +46,14 @@ resource "juju_application" "self-signed-certificates" {
   constraints = var.self-signed-certificates.constraints
   config      = var.self-signed-certificates.config
 
-  placement = length(var.self-signed-certificates.machines) == 1 ? var.self-signed-certificates.machines[0] : null
+  machines = (var.self-signed-certificates.machines == null || length(var.self-signed-certificates.machines) == 0) ? null : var.self-signed-certificates.machines
 }
 
 # Integrate with the self-signed-certificates if tls is enabled
 resource "juju_integration" "tls-opensearch_dashboards_integration" {
   for_each = var.tls ? { "deployed" = true } : {}
 
-  model = var.model
+  model_uuid = var.model_uuid
 
   application {
     name = juju_application.self-signed-certificates["deployed"].name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,8 +25,8 @@ variable "config" {
   default     = {}
 }
 
-variable "model" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -77,8 +77,8 @@ async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
         subprocess.run(["sudo", "snap", "install", "--classic", "microk8s"], check=True)
         subprocess.run(["sudo", "snap", "install", "--classic", "kubectl"], check=True)
 
-        # Configure Dockerhub Mirror 
-        # The self hosted runners would need to leverage the docker hub 
+        # Configure Dockerhub Mirror
+        # The self hosted runners would need to leverage the docker hub
         # mirror in order to alleviate the problems of rate limiting in docker
         # Please check https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-avoid-dockerhub-rate-limits/
         dockerhub_mirror = os.environ.get("DOCKERHUB_MIRROR", None)
@@ -89,10 +89,10 @@ capabilities = ["pull", "resolve"]
 """
             file_path = "/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml"
             directory = os.path.dirname(file_path)
-            if not os.path.exists(directory): 
+            if not os.path.exists(directory):
                 logger.error("The 'hosts.toml' for docker io server configuration don't exist")
             else:
-                # Write the content 
+                # Write the content
                 print(f"Writing configuration to {file_path}...")
                 subprocess.run(
                     ["sudo", "tee", file_path],
@@ -101,15 +101,9 @@ capabilities = ["pull", "resolve"]
                     check=True,
                     stdout=subprocess.DEVNULL,  # Suppress tee output to console
                 )
-                subprocess.run(
-                    ["sudo", "microk8s", "stop"],
-                    check=True
-                )
-                subprocess.run(
-                    ["sudo", "microk8s", "start"],
-                    check=True
-                )
-        
+                subprocess.run(["sudo", "microk8s", "stop"], check=True)
+                subprocess.run(["sudo", "microk8s", "start"], check=True)
+
         subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
         subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)
         subprocess.run(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -76,6 +76,40 @@ async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
     try:
         subprocess.run(["sudo", "snap", "install", "--classic", "microk8s"], check=True)
         subprocess.run(["sudo", "snap", "install", "--classic", "kubectl"], check=True)
+
+        # Configure Dockerhub Mirror 
+        # The self hosted runners would need to leverage the docker hub 
+        # mirror in order to alleviate the problems of rate limiting in docker
+        # Please check https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-avoid-dockerhub-rate-limits/
+        dockerhub_mirror = os.environ.get("DOCKERHUB_MIRROR", None)
+        if dockerhub_mirror:
+            docker_io_host_content = f"""server = "{dockerhub_mirror}"
+[host."{dockerhub_mirror}"]
+capabilities = ["pull", "resolve"]
+"""
+            file_path = "/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml"
+            directory = os.path.dirname(file_path)
+            if not os.path.exists(directory): 
+                logger.error("The 'hosts.toml' for docker io server configuration don't exist")
+            else:
+                # Write the content 
+                print(f"Writing configuration to {file_path}...")
+                subprocess.run(
+                    ["sudo", "tee", file_path],
+                    input=docker_io_host_content,
+                    text=True,
+                    check=True,
+                    stdout=subprocess.DEVNULL,  # Suppress tee output to console
+                )
+                subprocess.run(
+                    ["sudo", "microk8s", "stop"],
+                    check=True
+                )
+                subprocess.run(
+                    ["sudo", "microk8s", "start"],
+                    check=True
+                )
+        
         subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
         subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)
         subprocess.run(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -87,10 +87,11 @@ async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
 [host."{dockerhub_mirror}"]
 capabilities = ["pull", "resolve"]
 """
-            file_path = "/var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml"
+            file_path = "/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io"
             directory = os.path.dirname(file_path)
             if not os.path.exists(directory):
-                logger.error("The 'hosts.toml' for docker io server configuration don't exist")
+                # Create the directory
+                subprocess.run(["sudo", "mkdir", "-p", directory], check=True)
             else:
                 # Write the content
                 print(f"Writing configuration to {file_path}...")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -92,18 +92,17 @@ capabilities = ["pull", "resolve"]
             if not os.path.exists(directory):
                 # Create the directory
                 subprocess.run(["sudo", "mkdir", "-p", directory], check=True)
-            else:
-                # Write the content
-                print(f"Writing configuration to {file_path}...")
-                subprocess.run(
-                    ["sudo", "tee", file_path],
-                    input=docker_io_host_content,
-                    text=True,
-                    check=True,
-                    stdout=subprocess.DEVNULL,  # Suppress tee output to console
-                )
-                subprocess.run(["sudo", "microk8s", "stop"], check=True)
-                subprocess.run(["sudo", "microk8s", "start"], check=True)
+            # Write the content
+            print(f"Writing configuration to {file_path}...")
+            subprocess.run(
+                ["sudo", "tee", file_path],
+                input=docker_io_host_content,
+                text=True,
+                check=True,
+                stdout=subprocess.DEVNULL,  # Suppress tee output to console
+            )
+            subprocess.run(["sudo", "microk8s", "stop"], check=True)
+            subprocess.run(["sudo", "microk8s", "start"], check=True)
 
         subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
         subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -74,35 +74,9 @@ async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
         return
 
     try:
-        subprocess.run(["sudo", "snap", "install", "--classic", "microk8s"], check=True)
-        subprocess.run(["sudo", "snap", "install", "--classic", "kubectl"], check=True)
-
-        # Configure Dockerhub Mirror
-        # The self hosted runners would need to leverage the docker hub
-        # mirror in order to alleviate the problems of rate limiting in docker
-        # Please check https://canonical-self-hosted-github-runner-docs.readthedocs-hosted.com/en/latest/usage/faq/how-to-avoid-dockerhub-rate-limits/
-        dockerhub_mirror = os.environ.get("DOCKERHUB_MIRROR", None)
-        if dockerhub_mirror:
-            docker_io_host_content = f"""server = "{dockerhub_mirror}"
-[host."{dockerhub_mirror}"]
-capabilities = ["pull", "resolve"]
-"""
-            file_path = "/opt/containerd/k8s-containerd/etc/containerd/hosts.d/docker.io"
-            directory = os.path.dirname(file_path)
-            if not os.path.exists(directory):
-                # Create the directory
-                subprocess.run(["sudo", "mkdir", "-p", directory], check=True)
-            # Write the content
-            print(f"Writing configuration to {file_path}...")
-            subprocess.run(
-                ["sudo", "tee", file_path],
-                input=docker_io_host_content,
-                text=True,
-                check=True,
-                stdout=subprocess.DEVNULL,  # Suppress tee output to console
-            )
-            subprocess.run(["sudo", "microk8s", "stop"], check=True)
-            subprocess.run(["sudo", "microk8s", "start"], check=True)
+        # Restart microk8s
+        subprocess.run(["sudo", "microk8s", "stop"], check=True)
+        subprocess.run(["sudo", "microk8s", "start"], check=True)
 
         subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
         subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)


### PR DESCRIPTION
This Pull Request updates the used terraform provider version to the latest version currently v1.0 . An important breaking change that comes with this version is the replacement of `model` with `model_uuid` in the `juju_application` resource. More informations can be found [here](https://github.com/juju/terraform-provider-juju/releases/tag/v1.0.0-rc1). 

**Note** This PR also includes a fix for the issue we had in multiple charms regarding `chamcraft test --list github-ci`