### PR TITLE
Release 2.19.4 and Fixing Microk8s installation on SelfHosted Runners

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -110,8 +110,9 @@ jobs:
           juju add-model test
       - name: Terraform deploy
         run: |
+          MODEL_UUID=$(juju show-model test | grep "model-uuid" | awk '{split($0, a, ": "); print a[2]}')
           pushd ./terraform
-          terraform apply -var='model=test' -auto-approve
+          terraform apply -var="model_uuid=$MODEL_UUID" -auto-approve
           popd
       - name: Wait for model and applications
         run: |

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -20,6 +20,8 @@ jobs:
       - name: Set up environment
         run: |
           sudo snap install charmcraft --classic
+          sudo snap install go --classic
+          go install github.com/snapcore/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -28,10 +30,14 @@ jobs:
           import json
           import os
           import subprocess
+          import pathlib
 
           spread_jobs = (
               subprocess.run(
-                  ["charmcraft", "test", "--list", "github-ci"], capture_output=True, check=True, text=True
+                  [pathlib.Path.home() / "go/bin/spread", "-list", "github-ci"],
+                  capture_output=True,
+                  check=True,
+                  text=True,
               )
               .stdout.strip()
               .split("\n")

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -118,6 +118,11 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
+      # TODO remove once done investigating
+      - name: Setup tmate session
+        uses: canonical/action-tmate@main
+        with:
+          detached: true
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -118,11 +118,6 @@ jobs:
         run: |
           sudo lxc image copy ubuntu:568f69ff1166 local:
           sudo lxc image alias create "juju/ubuntu@22.04/amd64" 568f69ff1166
-      # TODO remove once done investigating
-      - name: Setup tmate session
-        uses: canonical/action-tmate@main
-        with:
-          detached: true
       - name: Run spread job
         timeout-minutes: 180
         id: spread

--- a/spread.yaml
+++ b/spread.yaml
@@ -98,6 +98,7 @@ backends:
       GCP_ACCESS_KEY: '$(HOST: echo $GCP_ACCESS_KEY)'
       GCP_SECRET_KEY: '$(HOST: echo $GCP_SECRET_KEY)'
       GCP_SERVICE_ACCOUNT: '$(HOST: echo $GCP_SERVICE_ACCOUNT)'
+      DOCKERHUB_MIRROR: '$(HOST: echo $DOCKERHUB_MIRROR)'
       # To install pipx on self-hosted runners
       CONCIERGE_EXTRA_DEBS: pipx
     systems:
@@ -121,6 +122,30 @@ prepare: |
   chown -R root:root "$SPREAD_PATH"
   cd "$SPREAD_PATH"
   snap install --classic concierge
+
+
+  if [[ -n "$DOCKERHUB_MIRROR" ]] && ([[ $SPREAD_TASK == *"oauth"* ]])
+  then
+    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
+    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
+    sudo snap install microk8s  --classic
+    sudo snap install kubectl --classic 
+    
+    # Wait for microk8s to populate iptables
+    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+    until [[ -n $(iptables --list | grep -i "microk8s") ]]
+    do
+      echo "MicroK8s has not yet configured iptables."
+      sleep 10
+    done
+    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+    server = "$DOCKERHUB_MIRROR"
+    [host."${DOCKERHUB_MIRROR#'https://'}"]
+    capabilities = ["pull", "resolve"]
+  EOF
+    microk8s stop
+    microk8s start
+  fi
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace

--- a/spread.yaml
+++ b/spread.yaml
@@ -123,28 +123,46 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-
-  if [[ -n "$DOCKERHUB_MIRROR" ]] && ([[ $SPREAD_TASK == *"oauth"* ]])
-  then
-    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
-    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
+  if ([[ $SPREAD_TASK == *"oauth"* ]]); then
+    # This test requires installing microk8s
     sudo snap install microk8s  --classic
     sudo snap install kubectl --classic 
-    
-    # Wait for microk8s to populate iptables
-    # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
-    until [[ -n $(iptables --list | grep -i "microk8s") ]]
-    do
-      echo "MicroK8s has not yet configured iptables."
-      sleep 10
+    # Check if we need to configure the docker hub mirror
+    if [[ -n "$DOCKERHUB_MIRROR" ]]; then
+      # Wait for microk8s to populate iptables
+      # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
+      until [[ -n $(iptables --list | grep -i "microk8s") ]]
+      do
+        echo "MicroK8s has not yet configured iptables."
+        sleep 10
+      done
+      tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
+      server = "$DOCKERHUB_MIRROR"
+      [host."${DOCKERHUB_MIRROR#'https://'}"]
+      capabilities = ["pull", "resolve"]
+    EOF
+      microk8s stop
+      microk8s start
+    fi
+    sudo microk8s status --wait-ready
+    echo "Enabling addons..."
+    microk8s enable dns 
+    microk8s enable hostpath-storage
+    microk8s enable metallb:10.64.140.43-10.64.140.49
+
+    #  Configure kubectl
+    echo "Configuring local kubectl..."
+    mkdir -p "$HOME/.kube"
+    microk8s config > "$HOME/.kube/config"
+    echo "Waiting for pods to stabilize..."
+    until kubectl get po -A --field-selector=status.phase!=Running 2>&1 | grep -q "No resources found"; do
+      echo "Some pods are not running. Retrying in 5 seconds..."
+      sleep 5
     done
-    tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-    server = "$DOCKERHUB_MIRROR"
-    [host."${DOCKERHUB_MIRROR#'https://'}"]
-    capabilities = ["pull", "resolve"]
-  EOF
-    microk8s stop
-    microk8s start
+
+    CONTROLLER_NAME=$(juju show-controller | yq eval 'keys | .[0]' -)
+    echo "Registering K8s with Juju..."
+    juju add-k8s uk8s --client --controller "$CONTROLLER_NAME"
   fi
 
   # Install charmcraft & pipx (on lxd-vm backend)

--- a/spread.yaml
+++ b/spread.yaml
@@ -144,7 +144,7 @@ prepare: |
       server = "$DOCKERHUB_MIRROR"
       [host."${DOCKERHUB_MIRROR#'https://'}"]
       capabilities = ["pull", "resolve"]
-    EOF
+      EOF
     fi
     microk8s stop
     microk8s start

--- a/spread.yaml
+++ b/spread.yaml
@@ -140,11 +140,10 @@ prepare: |
         echo "MicroK8s has not yet configured iptables."
         sleep 10
       done
-      tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml << EOF
-      server = "$DOCKERHUB_MIRROR"
-      [host."${DOCKERHUB_MIRROR#'https://'}"]
-      capabilities = ["pull", "resolve"]
-      EOF
+      # Use printf to avoid YAML/Heredoc indentation issues
+      printf 'server = "%s"\n[host."%s"]\ncapabilities = ["pull", "resolve"]\n' \
+        "$DOCKERHUB_MIRROR" "${DOCKERHUB_MIRROR#'https://'}" \
+        | sudo tee /var/snap/microk8s/current/args/certs.d/docker.io/hosts.toml > /dev/null
     fi
     microk8s stop
     microk8s start

--- a/spread.yaml
+++ b/spread.yaml
@@ -123,12 +123,16 @@ prepare: |
   cd "$SPREAD_PATH"
   snap install --classic concierge
 
-  if ([[ $SPREAD_TASK == *"oauth"* ]]); then
-    # This test requires installing microk8s
+  if [[ $SPREAD_TASK == *"oauth"* ]]
+  then
+    # Running on IS-hosted runner; configure microk8s to use Docker Hub mirror
+    # Run before concierge prepare because of https://github.com/canonical/concierge/issues/75
     sudo snap install microk8s  --classic
     sudo snap install kubectl --classic 
-    # Check if we need to configure the docker hub mirror
-    if [[ -n "$DOCKERHUB_MIRROR" ]]; then
+    sudo snap install yq
+    
+    if [[ -n "$DOCKERHUB_MIRROR" ]]
+    then
       # Wait for microk8s to populate iptables
       # https://chat.canonical.com/canonical/pl/jo5cg6wqjjrudqd5ybj6hhttee
       until [[ -n $(iptables --list | grep -i "microk8s") ]]
@@ -141,32 +145,30 @@ prepare: |
       [host."${DOCKERHUB_MIRROR#'https://'}"]
       capabilities = ["pull", "resolve"]
     EOF
-      microk8s stop
-      microk8s start
     fi
-    sudo microk8s status --wait-ready
-    echo "Enabling addons..."
-    microk8s enable dns 
+    microk8s stop
+    microk8s start
+    microk8s enable dns
     microk8s enable hostpath-storage
     microk8s enable metallb:10.64.140.43-10.64.140.49
-
-    #  Configure kubectl
-    echo "Configuring local kubectl..."
-    mkdir -p "$HOME/.kube"
-    microk8s config > "$HOME/.kube/config"
-    echo "Waiting for pods to stabilize..."
+    mkdir -p ~/.kube
+    microk8s config > ~/.kube/config
+    
+    echo "Waiting for all pods to be in 'Running' phase..."
     until kubectl get po -A --field-selector=status.phase!=Running 2>&1 | grep -q "No resources found"; do
       echo "Some pods are not running. Retrying in 5 seconds..."
       sleep 5
     done
-
-    CONTROLLER_NAME=$(juju show-controller | yq eval 'keys | .[0]' -)
-    echo "Registering K8s with Juju..."
-    juju add-k8s uk8s --client --controller "$CONTROLLER_NAME"
+    echo "Success: All pods are running!"
   fi
 
   # Install charmcraft & pipx (on lxd-vm backend)
   concierge prepare --trace
+
+  if [[ $SPREAD_TASK == *"oauth"* ]]
+  then
+    /snap/bin/juju add-k8s uk8s --client --controller $(/snap/bin/juju show-controller | yq "keys | .[0]")
+  fi
 
   pipx install tox poetry
 prepare-each: |

--- a/src/literals.py
+++ b/src/literals.py
@@ -4,7 +4,7 @@
 
 """Collection of global literals for the charm."""
 
-OPENSEARCH_DASHBOARDS_SNAP_REVISION = "41"
+OPENSEARCH_DASHBOARDS_SNAP_REVISION = "53"
 
 SUBSTRATE = "vm"
 CHARM_KEY = "opensearch-dashboards"
@@ -22,10 +22,10 @@ SERVER_PORT = 5601
 
 DEPENDENCIES = {
     "osd_upstream": {
-        "dependencies": {"opensearch": "2.19.2"},
+        "dependencies": {"opensearch": "2.19.4"},
         "name": "opensearch-dashboards",
         "upgrade_supported": ">=2",
-        "version": "2.19.2",
+        "version": "2.19.4",
     },
 }
 

--- a/src/literals.py
+++ b/src/literals.py
@@ -4,7 +4,7 @@
 
 """Collection of global literals for the charm."""
 
-OPENSEARCH_DASHBOARDS_SNAP_REVISION = "53"
+OPENSEARCH_DASHBOARDS_SNAP_REVISION = "54"
 
 SUBSTRATE = "vm"
 CHARM_KEY = "opensearch-dashboards"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -10,7 +10,7 @@ resource "juju_application" "opensearch-dashboards" {
     base     = var.base
   }
   config      = var.config
-  model       = var.model
+  model_uuid  = var.model_uuid
   name        = var.app_name
   units       = var.units
   constraints = var.constraints
@@ -35,7 +35,7 @@ resource "juju_application" "opensearch-dashboards" {
 resource "juju_application" "self-signed-certificates" {
   for_each = var.tls ? { "deployed" = true } : {}
 
-  model = var.model
+  model_uuid = var.model_uuid
 
   charm {
     name     = "self-signed-certificates"
@@ -45,15 +45,14 @@ resource "juju_application" "self-signed-certificates" {
   }
   constraints = var.self-signed-certificates.constraints
   config      = var.self-signed-certificates.config
-
-  placement = length(var.self-signed-certificates.machines) == 1 ? var.self-signed-certificates.machines[0] : null
+    machines = (var.self-signed-certificates.machines == null || length(var.self-signed-certificates.machines) == 0) ? null : var.self-signed-certificates.machines
 }
 
 # Integrate with the self-signed-certificates if tls is enabled
 resource "juju_integration" "tls-opensearch_dashboards_integration" {
   for_each = var.tls ? { "deployed" = true } : {}
 
-  model = var.model
+  model_uuid = var.model_uuid
 
   application {
     name = juju_application.self-signed-certificates["deployed"].name

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -25,8 +25,8 @@ variable "config" {
   default     = {}
 }
 
-variable "model" {
-  description = "Model name"
+variable "model_uuid" {
+  description = "Model UUID"
   type        = string
 }
 

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -7,7 +7,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = ">= 0.20.0"
+      version = "~> 1.0"
     }
   }
 }

--- a/tests/integration/bundle-iam.yaml
+++ b/tests/integration/bundle-iam.yaml
@@ -1,0 +1,92 @@
+---
+bundle: kubernetes
+name: identity-platform
+description: |
+  The Canonical Identity Platform is a composable identity broker and identity provider based on open source products.
+docs: https://discourse.charmhub.io/t/canonical-identity-platform/11825
+website: https://github.com/canonical/iam-bundle
+issues: https://github.com/canonical/iam-bundle/issues
+applications:
+  hydra:
+    charm: hydra
+    revision: 339
+    resources:
+      oci-image: ghcr.io/canonical/hydra:2.3.0-canonical
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  kratos:
+    charm: kratos
+    revision: 500
+    resources:
+      oci-image: ghcr.io/canonical/kratos:1.3.1
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  kratos-external-idp-integrator:
+    charm: kratos-external-idp-integrator
+    channel: latest/edge
+    revision: 245
+    scale: 1
+    series: jammy
+  identity-platform-login-ui-operator:
+    charm: identity-platform-login-ui-operator
+    revision: 146
+    resources:
+      oci-image: ghcr.io/canonical/identity-platform-login-ui:v0.21.2
+    channel: latest/edge
+    scale: 1
+    series: jammy
+    trust: true
+  postgresql-k8s:
+    charm: postgresql-k8s
+    channel: 14/stable
+    resources:
+      postgresql-image: ghcr.io/canonical/charmed-postgresql@sha256:e2283194f7f8d9997fb06f0fd1ab0ec3938ce73ac001133bd8fd393ebe83acc7
+    series: jammy
+    scale: 1
+    trust: true
+    options:
+      plugin_pg_trgm_enable: true
+      plugin_btree_gin_enable: true
+  self-signed-certificates:
+    charm: self-signed-certificates
+    revision: 155
+    channel: latest/stable
+    scale: 1
+  traefik-admin:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 176
+    resources:
+      traefik-image: docker.io/ubuntu/traefik:2-22.04
+    series: focal
+    scale: 1
+    trust: true
+  traefik-public:
+    charm: traefik-k8s
+    channel: latest/stable
+    revision: 176
+    resources:
+      traefik-image: docker.io/ubuntu/traefik:2-22.04
+    series: focal
+    scale: 1
+    trust: true
+relations:
+  - [hydra:pg-database, postgresql-k8s:database]
+  - [kratos:pg-database, postgresql-k8s:database]
+  - [kratos:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [kratos-external-idp-integrator:kratos-external-idp, kratos:kratos-external-idp]
+  - [hydra:admin-ingress, traefik-admin:ingress]
+  - [hydra:public-ingress, traefik-public:ingress]
+  - [kratos:admin-ingress, traefik-admin:ingress]
+  - [kratos:public-ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:ingress, traefik-public:ingress]
+  - [identity-platform-login-ui-operator:hydra-endpoint-info, hydra:hydra-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, hydra:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:ui-endpoint-info, kratos:ui-endpoint-info]
+  - [identity-platform-login-ui-operator:kratos-info, kratos:kratos-info]
+  - [traefik-admin:certificates, self-signed-certificates:certificates]
+  - [traefik-public:certificates, self-signed-certificates:certificates]

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -74,8 +74,10 @@ async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
         return
 
     try:
-        subprocess.run(["sudo", "snap", "install", "--classic", "microk8s"], check=True)
-        subprocess.run(["sudo", "snap", "install", "--classic", "kubectl"], check=True)
+        # Start microk8s
+
+        subprocess.run(["sudo", "microk8s", "stop"], check=True)
+        subprocess.run(["sudo", "microk8s", "start"], check=True)
         subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
         subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)
         subprocess.run(

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,14 +1,11 @@
 import logging
 import os
-import pathlib
 import subprocess
 from asyncio import sleep
 from typing import Any, AsyncGenerator
 
 import pytest
-import yaml
 from pytest_operator.plugin import OpsTest
-from tenacity import Retrying, stop_after_delay, wait_fixed
 
 logger = logging.getLogger(__name__)
 
@@ -58,88 +55,8 @@ def application_charm() -> str:
 
 
 @pytest.fixture(scope="module")
-async def microk8s_cloud(ops_test: OpsTest) -> AsyncGenerator[None, Any]:
-    """Install and configure MicroK8s as second cloud on the same juju controller.
-
-    Skips if it configured already. Automatically removes connection to the created
-    cloud and removes MicroK8s from system unless keep models parameter is used.
-    """
-    controller_name = next(
-        iter(yaml.safe_load(subprocess.check_output(["juju", "show-controller"])))
-    )
-
-    clouds = await ops_test._controller.clouds()
-    if f"cloud-{MICROK8S_CLOUD_NAME}" in clouds.clouds:
-        yield None
-        return
-
-    try:
-        # Start microk8s
-
-        subprocess.run(["sudo", "microk8s", "stop"], check=True)
-        subprocess.run(["sudo", "microk8s", "start"], check=True)
-        subprocess.run(["sudo", "microk8s", "enable", "dns"], check=True)
-        subprocess.run(["sudo", "microk8s", "enable", "hostpath-storage"], check=True)
-        subprocess.run(
-            ["sudo", "microk8s", "enable", "metallb:10.64.140.43-10.64.140.49"],
-            check=True,
-        )
-
-        # Configure kubectl now
-        subprocess.run(["mkdir", "-p", str(pathlib.Path.home() / ".kube")], check=True)
-        kubeconfig = subprocess.check_output(["sudo", "microk8s", "config"])
-        with open(str(pathlib.Path.home() / ".kube" / "config"), "w") as f:
-            f.write(kubeconfig.decode())
-        for attempt in Retrying(stop=stop_after_delay(150), wait=wait_fixed(15)):
-            with attempt:
-                if (
-                    len(
-                        subprocess.check_output(
-                            "kubectl get po -A  --field-selector=status.phase!=Running",
-                            shell=True,
-                            stderr=subprocess.DEVNULL,
-                        ).decode()
-                    )
-                    != 0
-                ):  # We got sth different from "No resources found." in stderr
-                    raise Exception()
-
-        # Add microk8s to the kubeconfig
-        subprocess.run(
-            [
-                "juju",
-                "add-k8s",
-                MICROK8S_CLOUD_NAME,
-                "--client",
-                "--controller",
-                controller_name,
-            ],
-            check=True,
-        )
-    except subprocess.CalledProcessError as e:
-        pytest.exit(str(e))
-
-    yield None
-
-    if not ops_test.keep_model:
-        subprocess.run(
-            [
-                "juju",
-                "remove-cloud",
-                "--client",
-                "--controller",
-                controller_name,
-                MICROK8S_CLOUD_NAME,
-            ],
-            check=True,
-        )
-        subprocess.run(["sudo", "snap", "remove", "--purge", "microk8s"], check=True)
-        subprocess.run(["sudo", "snap", "remove", "--purge", "kubectl"], check=True)
-
-
-@pytest.fixture(scope="module")
 async def ops_test_microk8s(
-    request, tmp_path_factory, ops_test: OpsTest, microk8s_cloud: None
+    request, tmp_path_factory, ops_test: OpsTest
 ) -> AsyncGenerator[OpsTest, Any]:
     """Create second OpsTest object, that is connected to the MicroK8s cloud.
 

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -54,7 +54,6 @@ async def test_deploy(ops_test: OpsTest, ops_test_microk8s: OpsTest, charm: str,
         OPENSEARCH_APP_NAME,
         channel="2/edge",
         num_units=2,
-        series=series,
         config=CONFIG_OPTS,
     )
 

--- a/tests/integration/test_oauth.py
+++ b/tests/integration/test_oauth.py
@@ -72,7 +72,7 @@ async def test_deploy_identity_bundle(
     """Deploy identity platform on K8s and wait for both models to complete deployments."""
     await deploy_identity_bundle(
         ops_test=ops_test_microk8s,
-        bundle_channel="latest/edge",
+        bundle_url="./tests/integration/bundle-iam.yaml",
         ext_idp_service=ext_idp_service,
     )
     await gather(

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -53,10 +53,10 @@ def harness():
     harness.charm.upgrade_events.dependency_model = OpensearchDashboardsDependencyModel(
         **{
             "osd_upstream": {
-                "dependencies": {"opensearch": "2.19.2"},
+                "dependencies": {"opensearch": "2.19.4"},
                 "name": "opensearch-dashboards",
                 "upgrade_supported": ">=2",
-                "version": "2.19.2",
+                "version": "2.19.4",
             },
         }
     )


### PR DESCRIPTION
This Pull Request groups a set of separate PRs that aims to reach a stable release of OpenSearch, The included worked items are as follows:

### Terraform Bump to 1.0
This updates the juju terraform provider version to the latest version currently v1.0 . An important breaking change that comes with this version is the replacement of model with model_uuid in the juju_application resource. More informations can be found [here](https://github.com/juju/terraform-provider-juju/releases/tag/v1.0.0-rc1). The original [PR](https://github.com/canonical/opensearch-dashboards-operator/pull/221).

### Update OpenSearch Dashboards Artifacts
This updates the snap revisions and dependencies used by opensearch dashboards to `2.19.4` . The original [PR](https://github.com/canonical/opensearch-dashboards-operator/pull/222).


## Fixing spread jobs 
This fixes the for the issue we had in multiple charms regarding `chamcraft test --list github-ci` and replace it by installing spread as a golang package and use it to collect testing jobs. 

## Fixing OAuth Failing Tests 
This handles two main issues:
- First issue is fixing installation of microk8s on Self-Hosted runners. The tests were failing since microk8s wasn't able to start its containers due to dockerhub rate limiting. The solution would be to configure `docker.io/hosts.toml` to make it use the available `DOCKERHUB_MIRROR` that is already configured in self-hosted runners. 
- Second issue is regarding the integration with `identity-platform` bundle. The `test_oauth.py` was deploying the bundle from `latest/edge` which weirdly was using a new version of the `identity-platform-login-ui-operator` that is not working and tests are not passing with that version. The solution to that would be to add `iam-bundle.yaml` in our tests temporary till the identity team fixes this, and install the bundle from the yaml file. 

