### PR TITLE
[DPE-9414] docs: Build submodule automation

### DIFF
--- a/.github/workflows/publish_docs_update.yml
+++ b/.github/workflows/publish_docs_update.yml
@@ -20,18 +20,6 @@ jobs:
             SUBMODULE_PATH: docs/dashboards
         steps:
 
-        - name: Checkout source repository
-          uses: actions/checkout@v6
-
-        - name: Get reviewers
-          id: get-reviewers
-          run: |
-            REVIEWERS=$(grep ".github/workflows/publish_docs_update.yml" .github/CODEOWNERS \
-                        | awk '{for(i=2;i<=NF;i++) print substr($i,2)}' \
-                        | paste -sd "," -)
-
-            echo "REVIEWERS=${REVIEWERS}" >> "$GITHUB_OUTPUT"
-
         - name: Checkout target repository
           uses: actions/checkout@v6
           with:
@@ -40,6 +28,16 @@ jobs:
             token: ${{ secrets.PAT }}
             submodules: true
             path: target-repo
+
+        - name: Get reviewers
+          id: get-reviewers
+          working-directory: target-repo
+          run: |
+            REVIEWERS=$(grep "${SUBMODULE_PATH}" .github/CODEOWNERS \
+                        | awk '{for(i=2;i<=NF;i++) print substr($i,2)}' \
+                        | paste -sd "," -)
+
+            echo "REVIEWERS=${REVIEWERS}" >> "$GITHUB_OUTPUT"
 
         - name: Configure git signing
           working-directory: target-repo

--- a/.github/workflows/publish_docs_update.yml
+++ b/.github/workflows/publish_docs_update.yml
@@ -1,0 +1,97 @@
+name: Update OpenSearch Dashboards docs submodule
+
+on:
+    push:
+        branches:
+        - 2/edge
+        paths:
+        - 'docs/**'
+
+    workflow_dispatch:
+
+jobs:
+    update-docs-submodule:
+        name: Open PR to update OpenSearch Dashboards docs submodule
+        runs-on: ubuntu-latest
+        env:
+            BASE_BRANCH: 2/edge
+            PR_BRANCH: auto/update-dashboards-docs-submodule-${{ github.sha }}
+            # Path to the submodule inside the opensearch-operator repository
+            SUBMODULE_PATH: docs/dashboards
+        steps:
+
+        - name: Checkout source repository
+          uses: actions/checkout@v6
+
+        - name: Get reviewers
+          id: get-reviewers
+          run: |
+            REVIEWERS=$(grep ".github/workflows/publish_docs_update.yml" .github/CODEOWNERS \
+                        | awk '{for(i=2;i<=NF;i++) print substr($i,2)}' \
+                        | paste -sd "," -)
+
+            echo "REVIEWERS=${REVIEWERS}" >> "$GITHUB_OUTPUT"
+
+        - name: Checkout target repository
+          uses: actions/checkout@v6
+          with:
+            repository: canonical/opensearch-operator
+            ref: ${{ env.BASE_BRANCH }}
+            token: ${{ secrets.PAT }}
+            submodules: true
+            path: target-repo
+
+        - name: Configure git signing
+          working-directory: target-repo
+          run: |
+            mkdir -p ~/.ssh
+            echo "${{ secrets.CI_COMMITS_SSH_SIGNING_KEY }}" > ~/.ssh/ssh-key
+            chmod 600 ~/.ssh/ssh-key
+
+            git config --global user.name "canonical-data-platform-bot"
+            git config --global user.email "canonical-data-platform-bot@canonical.com"
+
+            git config --global gpg.format ssh
+            git config --global user.signingkey ~/.ssh/ssh-key
+            git config --global commit.gpgsign true
+
+        - name: Update submodule to latest commit
+          working-directory: target-repo
+          run: |
+            cd "${SUBMODULE_PATH}"
+            git fetch origin
+            git checkout ${{ github.sha }}
+            cd ..
+            git add "${SUBMODULE_PATH}"
+
+        - name: Commit changes
+          working-directory: target-repo
+          run: |
+            if git ls-remote --exit-code --heads origin "${PR_BRANCH}" >/dev/null 2>&1; then
+                echo "ERROR: Branch '${PR_BRANCH}' already exists on remote. Refusing to overwrite it."
+                exit 1
+            fi
+
+            git checkout -b "${PR_BRANCH}"
+            git commit -m "chore: Update OpenSearch Dashboards docs submodule to ${{ github.sha }}"
+
+        - name: Push branch
+          working-directory: target-repo
+          run: |
+            git push origin "${PR_BRANCH}"
+
+        - name: Open Pull Request
+          working-directory: target-repo
+          env:
+            GITHUB_TOKEN: ${{ secrets.PAT }}
+          run: |
+            BODY="Automated update of the OpenSearch Dashboards docs submodule to commit [\`${{ github.sha }}\`](https://github.com/canonical/opensearch-dashboards-operator/commit/${{ github.sha }})."
+
+            PR_URL=$(gh pr create \
+                --title "chore: Update OpenSearch Dashboards docs submodule" \
+                --body "${BODY}" \
+                --base "${{ env.BASE_BRANCH }}" \
+                --head "${PR_BRANCH}" \
+                --reviewer "${{ steps.get-reviewers.outputs.REVIEWERS }}"
+            )
+            echo "- ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Add a GitHub workflow that automatically opens a PR in the [opensearch-operator](https://github.com/canonical/opensearch-operator) repository to update the OpenSearch Dashboards docs submodule whenever changes are pushed to the `docs` directory on the `2/edge` branch.

## How it works

1. Triggered on push to `2/edge` when `docs/**` files change, or manually via `workflow_dispatch`.
2. Checks out `canonical/opensearch-operator` at `2/edge` with its submodules initialised.
3. Reads the target repo's `.github/CODEOWNERS` to find owners of the `docs/dashboards`
   submodule path and automatically assigns them as reviewers on the opened PR.
4. Updates the submodule pointer to the triggering commit SHA.
5. Signs the commit using the `canonical-data-platform-bot` SSH signing key.
6. Opens a PR against `2/edge` in the OpenSearch operator repo with the submodule bump.

## Prerequisites

The following secrets must be configured in the repository settings before
this workflow can run successfully:

- `PAT` — a Personal Access Token with `repo` scope for `canonical/opensearch-operator`
- `CI_COMMITS_SSH_SIGNING_KEY` — the bot's SSH private key for signed commits

## Notes

- The autogenerated PR branch name includes the triggering SHA (`auto/update-dashboards-docs-submodule-<sha>`) to avoid collisions between concurrent runs.
- The workflow will fail early if the branch already exists on the remote.