### PR TITLE
fix: start snap if dead

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -156,7 +156,7 @@ class OpensearchDashboardsCharm(CharmBase):
         outdated_status = [MSG_WAITING_FOR_PEER]
 
         # attempt startup of server
-        if not self.state.unit_server.started:
+        if not self.workload.alive():
             self.init_server()
 
         # don't delay scale-down leader ops by restarting dying unit


### PR DESCRIPTION
fixes https://github.com/canonical/opensearch-dashboards-operator/issues/242

TLDR; `state.unit_server.started` does not reflect the actual server state, and the charm never notices or fixes a not-running dashboards snap