### PR TITLE
patch: fix spread installation

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo snap install charmcraft --classic
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
           pipx install tox poetry
       - name: Collect spread jobs
         id: collect-jobs
@@ -106,7 +106,7 @@ jobs:
       # https://github.com/canonical/charmcraft/issues/2130 fixed
       - run: |
           sudo snap install go --classic
-          go install github.com/snapcore/spread/cmd/spread@latest
+          go install github.com/canonical/spread/cmd/spread@latest
       - name: Download packed charm(s)
         timeout-minutes: 5
         uses: actions/download-artifact@v4


### PR DESCRIPTION
This pull request updates the integration test workflow to use the maintained `spread` tool repository under the `canonical` namespace instead of `snapcore`. This ensures that the workflow pulls the latest and officially supported version of the tool.

Dependency update in workflow:

* Updated the `go install` command in `.github/workflows/integration_test.yaml` to install `spread` from `github.com/canonical/spread/cmd/spread` instead of `github.com/snapcore/spread/cmd/spread`. [[1]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L24-R24) [[2]](diffhunk://#diff-f61384d930ecca9b388b7d547b0c10b6c977f087b106b0747d64dad87a96daa0L109-R109)