### PR TITLE
docs: Fix dashboards docs update workflow

### DIFF
--- a/.github/workflows/publish_docs_update.yml
+++ b/.github/workflows/publish_docs_update.yml
@@ -60,7 +60,7 @@ jobs:
           working-directory: target-repo
           run: |
             cd "${SUBMODULE_PATH}"
-            git fetch origin
+            git fetch --depth=1 origin ${{ github.sha }}
             git checkout ${{ github.sha }}
             cd ../..
             git add "${SUBMODULE_PATH}"

--- a/.github/workflows/publish_docs_update.yml
+++ b/.github/workflows/publish_docs_update.yml
@@ -33,9 +33,12 @@ jobs:
           id: get-reviewers
           working-directory: target-repo
           run: |
-            REVIEWERS=$(grep "${SUBMODULE_PATH}" .github/CODEOWNERS \
-                        | awk '{for(i=2;i<=NF;i++) print substr($i,2)}' \
-                        | paste -sd "," -)
+            REVIEWERS=""
+            if [[ -f .github/CODEOWNERS ]]; then
+                REVIEWERS=$(grep "${SUBMODULE_PATH}" .github/CODEOWNERS \
+                            | awk '{for(i=2;i<=NF;i++) print substr($i,2)}' \
+                            | paste -sd "," -)
+            fi
 
             echo "REVIEWERS=${REVIEWERS}" >> "$GITHUB_OUTPUT"
 
@@ -59,7 +62,7 @@ jobs:
             cd "${SUBMODULE_PATH}"
             git fetch origin
             git checkout ${{ github.sha }}
-            cd ..
+            cd ../..
             git add "${SUBMODULE_PATH}"
 
         - name: Commit changes
@@ -85,11 +88,16 @@ jobs:
           run: |
             BODY="Automated update of the OpenSearch Dashboards docs submodule to commit [\`${{ github.sha }}\`](https://github.com/canonical/opensearch-dashboards-operator/commit/${{ github.sha }})."
 
+            REVIEWER_FLAG=""
+            if [[ -n "${{ steps.get-reviewers.outputs.REVIEWERS }}" ]]; then
+                REVIEWER_FLAG="--reviewer ${{ steps.get-reviewers.outputs.REVIEWERS }}"
+            fi
+
             PR_URL=$(gh pr create \
                 --title "chore: Update OpenSearch Dashboards docs submodule" \
                 --body "${BODY}" \
                 --base "${{ env.BASE_BRANCH }}" \
                 --head "${PR_BRANCH}" \
-                --reviewer "${{ steps.get-reviewers.outputs.REVIEWERS }}"
+                ${REVIEWER_FLAG}
             )
             echo "- ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish_docs_update.yml
+++ b/.github/workflows/publish_docs_update.yml
@@ -88,9 +88,9 @@ jobs:
           run: |
             BODY="Automated update of the OpenSearch Dashboards docs submodule to commit [\`${{ github.sha }}\`](https://github.com/canonical/opensearch-dashboards-operator/commit/${{ github.sha }})."
 
-            REVIEWER_FLAG=""
+            REVIEWER_ARGS=()
             if [[ -n "${{ steps.get-reviewers.outputs.REVIEWERS }}" ]]; then
-                REVIEWER_FLAG="--reviewer ${{ steps.get-reviewers.outputs.REVIEWERS }}"
+                REVIEWER_ARGS=(--reviewer "${{ steps.get-reviewers.outputs.REVIEWERS }}")
             fi
 
             PR_URL=$(gh pr create \
@@ -98,6 +98,6 @@ jobs:
                 --body "${BODY}" \
                 --base "${{ env.BASE_BRANCH }}" \
                 --head "${PR_BRANCH}" \
-                ${REVIEWER_FLAG}
+                "${REVIEWER_ARGS[@]}"
             )
             echo "- ${PR_URL}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Fixed the `docs/docs` directory path failure. We need to go from `docs/dashboards` upwards two levels, instead of just one. Replaced with `cd ../..`.
Fixed a potential issue with the CODEOWNERS file being empty. We check for its existence and only add the reviewers if the file exists.

[Workflow Logs](https://github.com/canonical/opensearch-dashboards-operator/actions/runs/24887830958/job/72872145797) | [Demo PR](https://github.com/canonical/opensearch-operator/pull/816)