### PR TITLE
patch: [DPE-10681] - Fix release

### DIFF
--- a/docs/reference/monitoring.md
+++ b/docs/reference/monitoring.md
@@ -14,7 +14,7 @@ of the exporter.
 
 To ensure you are referencing the latest default alert rules, check the source file
 of alert definitions in the repository's
-[prometheus_alerts.yaml](https://github.com/canonical/opensearch-dashboards-operator/blob/2/edge/src/alert_rules/prometheus/prometheus_alerts.yaml)
+[prometheus_alerts.yaml](https://github.com/canonical/opensearch-dashboards-operator/blob/2/edge/kubernetes/src/alert_rules/prometheus/prometheus_alerts.yaml)
 file.
 
 ## Default alert rules

--- a/kubernetes/metadata.yaml
+++ b/kubernetes/metadata.yaml
@@ -25,7 +25,7 @@ resources:
   opensearch-dashboards-image:
     type: oci-image
     description: OCI image for opensearch-dashboards
-    upstream-source: ghcr.io/canonical/charmed-opensearch-dashboards:2.19.5-24.04_edge@sha256:57cd5a8e03bc80704bf64843f4d4309744ac6a4c92469169bbf4a4a1f7e81046
+    upstream-source: ghcr.io/canonical/charmed-opensearch-dashboards@sha256:57cd5a8e03bc80704bf64843f4d4309744ac6a4c92469169bbf4a4a1f7e81046
 
 peers:
   dashboard_peers:


### PR DESCRIPTION
fix docs reference after charm split and fix 
```
Could not inspect OCI image: Error parsing image name 
"docker://ghcr.io/canonical/charmed-opensearch-dashboards:2.19.5-24.04_edge@sha2
56:57cd5a8e03bc80704bf64843f4d4309744ac6a4c92469169bbf4a4a1f7e81046": Docker 
references with both a tag and digest are currently not supported```